### PR TITLE
Extract Audiences::Criterion from Audiences::Context

### DIFF
--- a/audiences-react/src/AudienceForm/CriteriaCard.tsx
+++ b/audiences-react/src/AudienceForm/CriteriaCard.tsx
@@ -1,13 +1,13 @@
 import { Card, Body, Flex, FlexItem, Caption } from "playbook-ui"
 
-import type { GroupCriteria } from "../types"
+import type { GroupCriterion } from "../types"
 import { CriteriaDescription } from "./CriteriaDescription"
 
 type CriteriaFieldsProps = React.PropsWithChildren & {
-  criteria?: GroupCriteria
+  criterion?: GroupCriterion
 }
-export function CriteriaCard({ criteria, children }: CriteriaFieldsProps) {
-  if (!criteria) {
+export function CriteriaCard({ criterion, children }: CriteriaFieldsProps) {
+  if (!criterion) {
     return null
   }
 
@@ -16,9 +16,14 @@ export function CriteriaCard({ criteria, children }: CriteriaFieldsProps) {
       <Flex justify="between">
         <FlexItem>
           <Body className="mr-3">
-            <CriteriaDescription criteria={criteria} />
+            <CriteriaDescription groups={criterion.groups} />
           </Body>
-          <Caption marginLeft="xs" size="xs" tag="span" text={criteria.count} />
+          <Caption
+            marginLeft="xs"
+            size="xs"
+            tag="span"
+            text={criterion.count}
+          />
         </FlexItem>
 
         <FlexItem>{children}</FlexItem>

--- a/audiences-react/src/AudienceForm/CriteriaDescription.tsx
+++ b/audiences-react/src/AudienceForm/CriteriaDescription.tsx
@@ -3,7 +3,7 @@ import join from "lodash/join"
 import map from "lodash/map"
 import isEmpty from "lodash/isEmpty"
 
-import { GroupCriteria, ScimObject } from "../types"
+import { Groups, ScimObject } from "../types"
 
 function toSentence(resources: ScimObject[]) {
   const names = map(resources, "displayName")
@@ -26,19 +26,19 @@ const Prepositions = {
 }
 
 type CriteriaDescriptionProps = {
-  criteria?: GroupCriteria
+  groups?: Groups
 }
-export function CriteriaDescription({ criteria }: CriteriaDescriptionProps) {
-  if (!criteria) return null
+export function CriteriaDescription({ groups }: CriteriaDescriptionProps) {
+  if (!groups || groups.groups) return null
 
   return (
     <div>
       {"All "}
       {map(Prepositions, (prep, key) =>
-        isEmpty(criteria[key]) ? null : (
-          <React.Fragment key={`criteria-${criteria.id}-${key}`}>
+        isEmpty(groups[key]) ? null : (
+          <React.Fragment key={`groups-${key}`}>
             {` ${prep} `}
-            <strong>{toSentence(criteria[key])}</strong>
+            <strong>{toSentence(groups[key])}</strong>
           </React.Fragment>
         ),
       )}

--- a/audiences-react/src/AudienceForm/CriteriaFieldsModal.tsx
+++ b/audiences-react/src/AudienceForm/CriteriaFieldsModal.tsx
@@ -30,7 +30,7 @@ export function CriteriaFieldsModal({
   return (
     <Dialog onClose={handleCancel} opened>
       <Dialog.Header>
-        <CriteriaDescription criteria={value} />
+        <CriteriaDescription groups={value.groups} />
       </Dialog.Header>
       <Dialog.Body>
         {map(groupResources, (resourceId) => (
@@ -38,7 +38,7 @@ export function CriteriaFieldsModal({
             resourceId={resourceId}
             key={`${current}.${resourceId}`}
             label={resourceId}
-            name={`${current}.${resourceId}`}
+            name={`${current}.groups.${resourceId}`}
           />
         ))}
       </Dialog.Body>

--- a/audiences-react/src/AudienceForm/CriteriaListFields.tsx
+++ b/audiences-react/src/AudienceForm/CriteriaListFields.tsx
@@ -8,9 +8,9 @@ import omitBy from "lodash/omitBy"
 import { CriteriaActions } from "./CriteriaActions"
 import { CriteriaCard } from "./CriteriaCard"
 import { CriteriaFieldsModal } from "./CriteriaFieldsModal"
-import { GroupCriteria } from "../types"
+import { GroupCriterion } from "../types"
 
-type GroupCriteriaField = GroupCriteria & {
+type GroupCriterionField = GroupCriterion & {
   id: string
 }
 type CriteriaListFieldsProps = {
@@ -22,17 +22,17 @@ export function CriteriaListFields({
   groupResources,
 }: CriteriaListFieldsProps) {
   const form = useFormContext()
+  const [currentEditing, editCriteria] = useState<number | undefined>()
   const { fields, remove, append } = useFieldArray({
     name,
     rules: {
       validate: (criteria) => {
-        return every(criteria, (c: GroupCriteria) => {
-          return !isEmpty(omitBy(c, isEmpty))
+        return every(criteria, (c: GroupCriterion) => {
+          return !isEmpty(omitBy(c.groups, isEmpty))
         })
       },
     },
   })
-  const [currentEditing, editCriteria] = useState<number | undefined>()
 
   const closeEditor = () => editCriteria(undefined)
   const watchFieldArray = form.watch(name) || []
@@ -54,18 +54,21 @@ export function CriteriaListFields({
   }
   const validateAndClose = async () => {
     const valid = await form.trigger(name)
+    closeEditor()
     if (!valid) {
       remove(currentEditing)
     }
-    closeEditor()
   }
 
   return (
     <Flex orientation="column" justify="center" align="stretch">
       <FlexItem>
-        {(controlledFields as GroupCriteriaField[]).map(
-          (criteria, index: number) => (
-            <CriteriaCard criteria={criteria} key={criteria.id}>
+        {(controlledFields as GroupCriterionField[]).map(
+          (criterion, index: number) => (
+            <CriteriaCard
+              criterion={criterion}
+              key={`criterion-${criterion.id}`}
+            >
               <CriteriaActions
                 onRequestRemove={() => handleRemoveCriteria(index)}
                 onRequestEdit={() => editCriteria(index)}

--- a/audiences-react/src/AudienceForm/index.tsx
+++ b/audiences-react/src/AudienceForm/index.tsx
@@ -1,5 +1,5 @@
 import { FormProvider, useForm } from "react-hook-form"
-import { UserInfo, Button, Card, Toggle, Caption, Flex } from "playbook-ui"
+import { Button, Card, Toggle, Caption, Flex } from "playbook-ui"
 
 import { Header } from "./Header"
 import { ScimResourceTypeahead } from "./ScimResourceTypeahead"
@@ -54,7 +54,7 @@ export const AudienceForm = ({
             {allowIndividuals && userResource && (
               <ScimResourceTypeahead
                 label="Other Members"
-                name="criteria.users"
+                name="extra_users"
                 resourceId={userResource}
               />
             )}

--- a/audiences-react/src/AudienceForm/index.tsx
+++ b/audiences-react/src/AudienceForm/index.tsx
@@ -48,7 +48,7 @@ export const AudienceForm = ({
           <Card.Body>
             <CriteriaListFields
               groupResources={groupResources}
-              name="criteria.groups"
+              name="criteria"
             />
 
             {allowIndividuals && userResource && (

--- a/audiences-react/src/types.ts
+++ b/audiences-react/src/types.ts
@@ -12,12 +12,12 @@ export interface GroupCriteria {
 }
 
 export interface AudienceCriteria {
-  users?: ScimObject[]
   groups?: GroupCriteria[]
 }
 
 export interface AudienceContext {
   match_all: boolean
+  extra_users: ScimObject[] | null
   criteria: AudienceCriteria
   total_members?: number
 }

--- a/audiences-react/src/types.ts
+++ b/audiences-react/src/types.ts
@@ -7,17 +7,18 @@ export interface ScimObject {
   }[]
 }
 
-export interface GroupCriteria {
+export interface Groups {
   [resourceType: string]: ScimObject[]
 }
 
-export interface AudienceCriteria {
-  groups?: GroupCriteria[]
+export interface GroupCriterion {
+  groups?: Groups
+  count?: number
 }
 
 export interface AudienceContext {
   match_all: boolean
   extra_users: ScimObject[] | null
-  criteria: AudienceCriteria
+  criteria: GroupCriterion[]
   total_members?: number
 }

--- a/audiences/Gemfile
+++ b/audiences/Gemfile
@@ -7,7 +7,7 @@ gemspec
 
 # Development tools
 gem "appraisal", "~> 2.5.0"
-# gem "debug", ">= 1.0.0"
+gem "debug", ">= 1.0.0"
 gem "foreman", "~> 0.87.2"
 gem "license_finder", ">= 7.0"
 gem "rails", "~> 7.0"

--- a/audiences/Gemfile.lock
+++ b/audiences/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
       rexml
     crass (1.0.6)
     date (3.3.3)
+    debug (1.8.0)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     diff-lcs (1.5.0)
     dry-cli (1.0.0)
     erubi (1.12.0)
@@ -94,6 +97,10 @@ GEM
     hashdiff (1.0.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.9.0)
+      rdoc
+      reline (>= 0.3.8)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     license_finder (7.1.0)
@@ -133,6 +140,8 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
@@ -172,7 +181,11 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.1.0)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     regexp_parser (2.8.2)
+    reline (0.4.0)
+      io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -237,6 +250,7 @@ GEM
       activesupport (>= 5.2.0)
     sqlite3 (1.6.8-arm64-darwin)
     sqlite3 (1.6.8-x86_64-linux)
+    stringio (3.0.9)
     thor (1.2.2)
     timeout (0.4.0)
     tomlrb (2.0.3)
@@ -269,6 +283,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal (~> 2.5.0)
   audiences!
+  debug (>= 1.0.0)
   foreman (~> 0.87.2)
   license_finder (>= 7.0)
   puma (~> 6.3)

--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -13,11 +13,15 @@ module Audiences
   private
 
     def render_context(context)
-      render json: context.as_json(only: %i[match_all criteria])
+      render json: context.as_json(only: %i[match_all extra_users criteria])
     end
 
     def context_params
-      params.permit(:match_all, criteria: {})
+      params.permit(
+        :match_all,
+        criteria: {},
+        extra_users: [:id, :displayName, { photos: %i[type value] }]
+      )
     end
   end
 end

--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -3,25 +3,25 @@
 module Audiences
   class ContextsController < ApplicationController
     def show
-      render_context Audiences.load(params[:key])
+      render_context Audiences.load(params.require(:key))
     end
 
     def update
-      render_context Audiences.update(params[:key], context_params.to_h)
+      render_context Audiences.update(params.require(:key), **context_params)
     end
 
   private
 
     def render_context(context)
-      render json: context.as_json(only: %i[match_all extra_users criteria])
+      render json: context.as_json(only: %i[match_all extra_users], include: { criteria: { only: %i[groups] } })
     end
 
     def context_params
       params.permit(
         :match_all,
-        criteria: {},
+        criteria: [groups: {}],
         extra_users: [:id, :displayName, { photos: %i[type value] }]
-      )
+      ).to_h.symbolize_keys
     end
   end
 end

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -5,7 +5,7 @@ module Audiences
   class Context < ApplicationRecord
     belongs_to :owner, polymorphic: true
 
-    store :criteria, accessors: %i[users groups], suffix: true
+    has_many :criteria, class_name: "Audiences::Criterion", dependent: :destroy
 
     # Finds or creates a context for the given owner
     #

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Audiences
+  class Criterion < ApplicationRecord
+    belongs_to :context, class_name: "Audiences::Context"
+
+    def self.map(criteria)
+      Array(criteria).map { new(_1) }
+    end
+  end
+end

--- a/audiences/db/migrate/20231114210454_add_extra_users_to_audiences_context.rb
+++ b/audiences/db/migrate/20231114210454_add_extra_users_to_audiences_context.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddExtraUsersToAudiencesContext < ActiveRecord::Migration[6.0]
+  def change
+    add_column :audiences_contexts, :extra_users, :json
+  end
+end

--- a/audiences/db/migrate/20231114210633_remove_criteria_from_audiences_context.rb
+++ b/audiences/db/migrate/20231114210633_remove_criteria_from_audiences_context.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveCriteriaFromAudiencesContext < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :audiences_contexts, :criteria, :json
+  end
+end

--- a/audiences/db/migrate/20231114215843_create_audiences_criterions.rb
+++ b/audiences/db/migrate/20231114215843_create_audiences_criterions.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAudiencesCriterions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :audiences_criterions do |t|
+      t.json :groups
+      t.references :context, null: false, foreign_key: { to_table: :audiences_contexts }
+
+      t.timestamps
+    end
+  end
+end

--- a/audiences/db/migrate/20231114215843_create_audiences_criterions.rb
+++ b/audiences/db/migrate/20231114215843_create_audiences_criterions.rb
@@ -4,7 +4,7 @@ class CreateAudiencesCriterions < ActiveRecord::Migration[6.0]
   def change
     create_table :audiences_criterions do |t|
       t.json :groups
-      t.references :context, null: false, foreign_key: { to_table: :audiences_contexts }
+      t.references :context, null: false, foreign_key: false
 
       t.timestamps
     end

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -43,8 +43,9 @@ module_function
   # @param params [Hash] the updated params
   # @return Audience::Context
   #
-  def update(key, attrs)
+  def update(key, criteria: [], **attrs)
     locate_context(key) do |context|
+      context.criteria.replace ::Audiences::Criterion.map(criteria)
       context.update!(attrs)
       context.readonly!
     end

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_202008) do
+ActiveRecord::Schema[6.0].define(version: 2023_11_14_210454) do
   create_table "audiences_contexts", force: :cascade do |t|
     t.string "owner_type", null: false
     t.integer "owner_id", null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_202008) do
     t.json "criteria"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "extra_users"
     t.index ["owner_type", "owner_id"], name: "index_audiences_contexts_on_owner_type_and_owner_id", unique: true
   end
 

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,16 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.0].define(version: 2023_11_14_210454) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_14_215843) do
   create_table "audiences_contexts", force: :cascade do |t|
     t.string "owner_type", null: false
     t.integer "owner_id", null: false
     t.boolean "match_all", default: false, null: false
-    t.json "criteria"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.json "extra_users"
     t.index ["owner_type", "owner_id"], name: "index_audiences_contexts_on_owner_type_and_owner_id", unique: true
+  end
+
+  create_table "audiences_criterions", force: :cascade do |t|
+    t.json "groups"
+    t.integer "context_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["context_id"], name: "index_audiences_criterions_on_context_id"
   end
 
   create_table "example_owners", force: :cascade do |t|
@@ -28,4 +35,5 @@ ActiveRecord::Schema[6.0].define(version: 2023_11_14_210454) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "audiences_criterions", "audiences_contexts", column: "context_id"
 end

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -35,5 +35,4 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_14_215843) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "audiences_criterions", "audiences_contexts", column: "context_id"
 end

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -25,15 +25,25 @@ RSpec.describe Audiences do
     end
 
     it "updates an direct resources collection" do
-      updated_context = Audiences.update(token, extra_users: [123, 321])
+      updated_context = Audiences.update(token, extra_users: [{ id: 123 }, { id: 321 }])
 
-      expect(updated_context.extra_users).to eql([123, 321])
+      expect(updated_context.extra_users).to eql([{ "id" => 123 }, { "id" => 321 }])
     end
 
     it "updates group criterion" do
-      updated_context = Audiences.update(token, extra_users: [123, 321])
+      updated_context = Audiences.update(
+        token,
+        criteria: [
+          { groups: { Departments: [{ id: 1 }, { id: 2 }], Territories: [{ id: 3 }, { id: 4 }] } },
+          { groups: { Branches: [{ id: 5 }, { id: 6 }], Titles: [{ id: 7 }, { id: 8 }] } },
+        ]
+      )
 
-      expect(updated_context.extra_users).to eql([123, 321])
+      expect(updated_context.criteria.size).to eql(2)
+      expect(updated_context.criteria.first.groups).to match({ "Departments" => [{ "id" => 1 }, { "id" => 2 }],
+                                                               "Territories" => [{ "id" => 3 }, { "id" => 4 }] })
+      expect(updated_context.criteria.last.groups).to match({ "Branches" => [{ "id" => 5 }, { "id" => 6 }],
+                                                              "Titles" => [{ "id" => 7 }, { "id" => 8 }] })
     end
   end
 end

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -25,9 +25,15 @@ RSpec.describe Audiences do
     end
 
     it "updates an direct resources collection" do
-      updated_context = Audiences.update(token, users_criteria: [123, 321])
+      updated_context = Audiences.update(token, extra_users: [123, 321])
 
-      expect(updated_context.criteria[:users]).to eql([123, 321])
+      expect(updated_context.extra_users).to eql([123, 321])
+    end
+
+    it "updates group criterion" do
+      updated_context = Audiences.update(token, extra_users: [123, 321])
+
+      expect(updated_context.extra_users).to eql([123, 321])
     end
   end
 end

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Audiences::Criterion do
+  describe "associations" do
+    it { is_expected.to belong_to(:context) }
+  end
+
+  describe ".map([])" do
+    it "builds contexts with the given " do
+      criteria = Audiences::Criterion.map(
+        [
+          { groups: { Departments: [{ id: 1 }] } },
+          { groups: { Territories: [{ id: 3 }] } },
+        ]
+      )
+
+      expect(criteria.size).to eql 2
+      expect(criteria.first.groups).to match({ "Departments" => [{ "id" => 1 }] })
+      expect(criteria.last.groups).to match({ "Territories" => [{ "id" => 3 }] })
+    end
+  end
+end

--- a/audiences/spec/requests/contexts_api_spec.rb
+++ b/audiences/spec/requests/contexts_api_spec.rb
@@ -9,30 +9,78 @@ RSpec.describe "/audiences", type: :request do
     it "responds with the audience context json" do
       get audience_context_path(example_owner)
 
-      expect(response.parsed_body).to match({ "match_all" => false, "criteria" => {} })
+      expect(response.parsed_body).to match({ "match_all" => false, "extra_users" => nil, "criteria" => {} })
     end
   end
 
   context "PUT /audiences/:context_key" do
     it "updates the audience context" do
-      put audience_context_path(example_owner), params: { match_all: true }
+      put audience_context_path(example_owner), as: :json, params: { match_all: true }
 
       context = Audiences::Context.for(example_owner)
 
       expect(context).to be_match_all
     end
 
-    it "updates the context resources" do
-      put audience_context_path(example_owner), params: { criteria: { users: [123] } }
+    it "updates the context extra users" do
+      put audience_context_path(example_owner),
+          as: :json,
+          params: { extra_users: [{ id: 123, displayName: "John Doe",
+                                    photos: [{ value: "http://example.com" }] }] }
 
       context = Audiences::Context.for(example_owner)
-      expect(context.users_criteria).to eql ["123"]
+      expect(context.extra_users).to eql [{
+        "id" => 123,
+        "displayName" => "John Doe",
+        "photos" => [{ "value" => "http://example.com" }],
+      }]
     end
 
     it "responds with the audience context json" do
-      put audience_context_path(example_owner), params: { match_all: true }
+      put audience_context_path(example_owner),
+          as: :json,
+          params: { extra_users: [{ id: 123, displayName: "John Doe",
+                                    photos: [{ value: "http://example.com" }] }] }
 
-      expect(response.parsed_body).to match({ "match_all" => true, "criteria" => {} })
+      expect(response.parsed_body).to match({
+                                              "match_all" => false,
+                                              "extra_users" => [{
+                                                "id" => 123,
+                                                "displayName" => "John Doe",
+                                                "photos" => [{ "value" => "http://example.com" }],
+                                              }],
+                                              "criteria" => {},
+                                            })
+    end
+
+    it "allows updating the group criteria" do
+      put audience_context_path(example_owner),
+          as: :json,
+          params: {
+            match_all: false,
+            criteria: {
+              groups: [
+                { Departments: [{ id: 123, displayName: "Finance" }],
+                  Territories: [{ id: 321, displayName: "Philadelphia" }] },
+                { Departments: [{ id: 789, displayName: "Sales" }],
+                  Territories: [{ id: 987, displayName: "Detroit" }] },
+              ],
+            },
+          }
+
+      expect(response.parsed_body).to match({
+                                              "match_all" => false,
+                                              "extra_users" => nil,
+                                              "criteria" => {
+                                                "groups" => [
+                                                  { "Departments" => [{ "id" => 123, "displayName" => "Finance" }],
+                                                    "Territories" => [{ "id" => 321,
+                                                                        "displayName" => "Philadelphia" }] },
+                                                  { "Departments" => [{ "id" => 789, "displayName" => "Sales" }],
+                                                    "Territories" => [{ "id" => 987, "displayName" => "Detroit" }] },
+                                                ],
+                                              },
+                                            })
     end
   end
 end

--- a/audiences/spec/requests/contexts_api_spec.rb
+++ b/audiences/spec/requests/contexts_api_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "/audiences", type: :request do
     it "responds with the audience context json" do
       get audience_context_path(example_owner)
 
-      expect(response.parsed_body).to match({ "match_all" => false, "extra_users" => nil, "criteria" => {} })
+      expect(response.parsed_body).to match({ "match_all" => false, "extra_users" => nil, "criteria" => [] })
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe "/audiences", type: :request do
                                                 "displayName" => "John Doe",
                                                 "photos" => [{ "value" => "http://example.com" }],
                                               }],
-                                              "criteria" => {},
+                                              "criteria" => [],
                                             })
     end
 
@@ -58,28 +58,32 @@ RSpec.describe "/audiences", type: :request do
           as: :json,
           params: {
             match_all: false,
-            criteria: {
-              groups: [
-                { Departments: [{ id: 123, displayName: "Finance" }],
-                  Territories: [{ id: 321, displayName: "Philadelphia" }] },
-                { Departments: [{ id: 789, displayName: "Sales" }],
-                  Territories: [{ id: 987, displayName: "Detroit" }] },
-              ],
-            },
+            criteria: [
+              { groups: { Departments: [{ id: 123, displayName: "Finance" }],
+                          Territories: [{ id: 321, displayName: "Philadelphia" }] } },
+              { groups: { Departments: [{ id: 789, displayName: "Sales" }],
+                          Territories: [{ id: 987, displayName: "Detroit" }] } },
+            ],
           }
 
       expect(response.parsed_body).to match({
                                               "match_all" => false,
                                               "extra_users" => nil,
-                                              "criteria" => {
-                                                "groups" => [
-                                                  { "Departments" => [{ "id" => 123, "displayName" => "Finance" }],
+                                              "criteria" => [
+                                                {
+                                                  "groups" => {
+                                                    "Departments" => [{ "id" => 123, "displayName" => "Finance" }],
                                                     "Territories" => [{ "id" => 321,
-                                                                        "displayName" => "Philadelphia" }] },
-                                                  { "Departments" => [{ "id" => 789, "displayName" => "Sales" }],
-                                                    "Territories" => [{ "id" => 987, "displayName" => "Detroit" }] },
-                                                ],
-                                              },
+                                                                        "displayName" => "Philadelphia" }],
+                                                  },
+                                                },
+                                                {
+                                                  "groups" => {
+                                                    "Departments" => [{ "id" => 789, "displayName" => "Sales" }],
+                                                    "Territories" => [{ "id" => 987, "displayName" => "Detroit" }],
+                                                  },
+                                                },
+                                              ],
                                             })
     end
   end


### PR DESCRIPTION
To support criterion level information, like the number of users matching it (see attachment 1), or the list of users matching a criterion (see attachment 2), we we'll need a model representing it.

Today this is represented as a full criteria JSON inside Audiences::Context, this story is about breaking this criteria down into a list of `extra_users` and Audience::Criterion models, where the list of users matching them will live.

- Replace criteria.users by extra_users
- Add debug in development
- Introduce criterion model
