### PR TITLE
Notify audience updates

### DIFF
--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -19,12 +19,18 @@ module Audiences
       where(owner: owner).first_or_create!
     end
 
+    # Total users within this context (see #users)
     def count
       users.size
     end
 
+    # All users within that Audience context. These include:
+    #
+    # - All users matching any of the criteria
+    # - All users set directly through `extra_users`
+    # - Users are listed once (uniquely)
     def users
-      [*extra_users, *criteria.flat_map(&:users)].uniq.compact
+      @users ||= [*extra_users, *criteria.flat_map(&:users)].uniq.compact
     end
 
   private

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -9,6 +9,8 @@ module Audiences
                         autosave: true,
                         dependent: :destroy
 
+    after_commit :notify
+
     # Finds or creates a context for the given owner
     #
     # @private
@@ -23,6 +25,12 @@ module Audiences
 
     def users
       [*extra_users, *criteria.flat_map(&:users)].uniq.compact
+    end
+
+  private
+
+    def notify
+      Audiences::Notifications.publish(self)
     end
   end
 end

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -47,6 +47,11 @@ Rails.application.config.to_prepare do
 end
 ```
 
+You can find a working example in our dummy app:
+
+- [initializer](../spec/dummy/config/initializers/audiences.rb)
+- [job class](../spec/dummy/app/jobs/update_memberships_job.rb)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -13,28 +13,38 @@ That can be done with a unobstrusive JS renderer like react-rails, or a custom o
 - The context URI: `audience_context_url(owner)` helper
 - The SCIM endpoint: `audience_scim_proxy_url` helper if using the [proxy](#configuring-the-scim-proxy), or the SCIM endpoint.
 
-### Listening to audience changes
+### Configuring the SCIM backend
 
-**TBD**
-
-### Configuring the SCIM proxy
-
-The Audience::ScimProxy should point to the real SCIM endpoint. The proxy allows you to configure the endpoint and the credentials/headers:
+The Audience::Scim should point to the real SCIM endpoint. The service allows you to configure the endpoint and the credentials/headers:
 
 I.e.:
 
 ```ruby
-# frozen_string_literal: true
+Audiences::Scim.client = Audiences::Scim::Client.new(
+  uri: ENV.fetch("SCIM_V2_API"),
+  headers: { "Authorization" => "Bearer #{ENV.fetch('SCIM_V2_TOKEN')}" }
+)
+```
 
-require "audiences/scim_proxy"
+### Listening to audience changes
 
-Audiences::ScimProxy.config = {
-  uri: "http://super-secret-scim.com/scim/v2/",
-  headers: {
-    "Authorization": "Beaer very-secret"
-  }
-  debug: $stdout,
-}
+The goal of audiences is to allow the app to keep up with a mutable group of people. To allow that, `Audiences` includes the `Audiences::Notifications` module, to allow the hosting app to subscribe to audiences related to a certain owner type, and react to that through a block:
+
+```ruby
+Rails.application.config.to_prepare do
+  Audiences::Notifications.subscribe Team do |context|
+    team.update_memberships(context.users)
+  end
+end
+```
+
+or scheduling an AcitiveJob:
+
+```ruby
+Rails.application.config.to_prepare do
+  Audiences::Notifications.subscribe Group, job: UpdateGroupMembershipsJob
+  Audiences::Notifications.subscribe Team, job: UpdateTeamMembershipsJob.set(queue: "low")
+end
 ```
 
 ## Installation

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -2,6 +2,7 @@
 
 require "audiences/version"
 require "audiences/scim"
+require "audiences/notifications"
 
 # Audiences system
 # Audiences pushes notifications to your rails app when a

--- a/audiences/lib/audiences/notifications.rb
+++ b/audiences/lib/audiences/notifications.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Audiences
+  # @private
+  module Notifications
+    mattr_reader :subscriptions, default: {}
+
+  module_function
+
+    def subscribe(owner_type, job: nil, &cbk)
+      subscriptions[owner_type] = job&.method(:perform_later) || cbk
+    end
+
+    def publish(context)
+      subscriptions[context.owner.class]&.call(context)
+    end
+  end
+end

--- a/audiences/spec/dummy/app/jobs/update_memberships_job.rb
+++ b/audiences/spec/dummy/app/jobs/update_memberships_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UpdateMembershipsJob < ApplicationJob
+  def perform(context)
+    owner = context.owner
+
+    owner.memberships = owner.memberships.build(
+      context.users.map do |user|
+        {
+          user_id: user["id"],
+          name: user["displayName"],
+          photo: user.dig("photos", 0, "value"),
+        }
+      end
+    )
+    owner.save!
+  end
+end

--- a/audiences/spec/dummy/app/jobs/update_memberships_job.rb
+++ b/audiences/spec/dummy/app/jobs/update_memberships_job.rb
@@ -2,9 +2,7 @@
 
 class UpdateMembershipsJob < ApplicationJob
   def perform(context)
-    owner = context.owner
-
-    owner.memberships = owner.memberships.build(
+    memberships = owner.memberships.build(
       context.users.map do |user|
         {
           user_id: user["id"],
@@ -13,6 +11,6 @@ class UpdateMembershipsJob < ApplicationJob
         }
       end
     )
-    owner.save!
+    context.owner.update!(memberships: memberships)
   end
 end

--- a/audiences/spec/dummy/app/models/example_membership.rb
+++ b/audiences/spec/dummy/app/models/example_membership.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ExampleMembership < ApplicationRecord
+end

--- a/audiences/spec/dummy/app/models/example_owner.rb
+++ b/audiences/spec/dummy/app/models/example_owner.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ExampleOwner < ApplicationRecord
+  has_many :memberships, class_name: "ExampleMembership", foreign_key: :owner_id, dependent: :destroy
 end

--- a/audiences/spec/dummy/app/views/example_owners/_example_owner.html.erb
+++ b/audiences/spec/dummy/app/views/example_owners/_example_owner.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id example_owner %>">
   <p>
     <strong>Name:</strong>
-    <%= example_owner.name %>
+    <%= example_owner.name %> (<%= @example_owner.memberships.count %> memberships)
   </p>
 
 </div>

--- a/audiences/spec/dummy/config/initializers/audiences.rb
+++ b/audiences/spec/dummy/config/initializers/audiences.rb
@@ -4,3 +4,7 @@ Audiences::Scim.client = Audiences::Scim::Client.new(
   uri: ENV.fetch("SCIM_V2_API", "http://example.com/scim/v2/"),
   headers: { "Authorization" => "Bearer 123456789" }
 )
+
+Rails.application.config.to_prepare do
+  Audiences::Notifications.subscribe ExampleOwner, job: UpdateMembershipsJob
+end

--- a/audiences/spec/dummy/db/migrate/20231127200326_create_example_memberships.rb
+++ b/audiences/spec/dummy/db/migrate/20231127200326_create_example_memberships.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateExampleMemberships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :example_memberships do |t|
+      t.belongs_to :owner, foreign_key: false
+      t.integer :user_id
+      t.string :name
+      t.string :photo
+      t.timestamps
+    end
+  end
+end

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_15_204932) do
+ActiveRecord::Schema.define(version: 2023_11_27_200326) do
 
   create_table "audiences_contexts", force: :cascade do |t|
     t.string "owner_type", null: false
@@ -30,6 +30,16 @@ ActiveRecord::Schema.define(version: 2023_11_15_204932) do
     t.json "users"
     t.datetime "refreshed_at"
     t.index ["context_id"], name: "index_audiences_criterions_on_context_id"
+  end
+
+  create_table "example_memberships", force: :cascade do |t|
+    t.integer "owner_id"
+    t.integer "user_id"
+    t.string "name"
+    t.string "photo"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["owner_id"], name: "index_example_memberships_on_owner_id"
   end
 
   create_table "example_owners", force: :cascade do |t|

--- a/audiences/spec/lib/audiences/notifications_spec.rb
+++ b/audiences/spec/lib/audiences/notifications_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Audiences::Notifications do
+  it "allows subscribing by owner type" do
+    owner = ExampleOwner.create
+    context = Audiences::Context.new(owner: owner)
+
+    expect do |blk|
+      Audiences::Notifications.subscribe ExampleOwner, &blk
+      Audiences::Notifications.publish context
+    end.to yield_with_args context
+  end
+
+  context "subscribing a job" do
+    it "allows subscribing a job to perform later" do
+      owner = ExampleOwner.create
+      context = Audiences::Context.create(owner: owner)
+      Audiences::Notifications.subscribe ExampleOwner, job: UpdateMembershipsJob
+
+      expect do
+        Audiences::Notifications.publish context
+      end.to have_enqueued_job(UpdateMembershipsJob).with(context).exactly(:once)
+    end
+
+    it "allows subscribing a job to perform later with options" do
+      owner = ExampleOwner.create
+      context = Audiences::Context.create(owner: owner)
+      Audiences::Notifications.subscribe ExampleOwner, job: UpdateMembershipsJob.set(queue: "low")
+
+      expect do
+        Audiences::Notifications.publish context
+      end.to have_enqueued_job(UpdateMembershipsJob).with(context)
+                                                    .on_queue("low")
+                                                    .exactly(:once)
+    end
+  end
+end

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -3,6 +3,19 @@
 require "rails_helper"
 
 RSpec.describe Audiences::Context do
+  describe "subscriptions" do
+    let(:owner) { ExampleOwner.create(name: "Example") }
+
+    it "publishes a notification about the context update" do
+      owner = ExampleOwner.create
+
+      expect do |blk|
+        Audiences::Notifications.subscribe ExampleOwner, &blk
+        Audiences::Context.create(owner: owner)
+      end.to yield_with_args
+    end
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:owner) }
   end

--- a/audiences/spec/rails_helper.rb
+++ b/audiences/spec/rails_helper.rb
@@ -17,9 +17,15 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
+ActiveJob::Base.queue_adapter = :test
+
 RSpec.configure do |config|
   config.include Rails.application.routes.url_helpers, type: :request
 
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
+
+  config.before do
+    Audiences::Notifications.subscriptions.clear
+  end
 end


### PR DESCRIPTION
Add a subscription system to Audiences, so the hosting system can execute callbacks/jobs to work on the updated audience users.

A callback will be executed whenever we update an audience. The same callback will execute when the audience is refreshed.
