### PR TITLE
Bump package version

### DIFF
--- a/audiences-react/package.json
+++ b/audiences-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audiences",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Audiences SCIM client",
   "files": [
     "dist"

--- a/audiences/Gemfile.lock
+++ b/audiences/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    audiences (1.0.0)
+    audiences (1.0.1)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_6_0.gemfile.lock
+++ b/audiences/gemfiles/rails_6_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.0.0)
+    audiences (1.0.1)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_6_1.gemfile.lock
+++ b/audiences/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.0.0)
+    audiences (1.0.1)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_7_0.gemfile.lock
+++ b/audiences/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.0.0)
+    audiences (1.0.1)
       rails (>= 6.0)
 
 GEM

--- a/audiences/lib/audiences/version.rb
+++ b/audiences/lib/audiences/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Audiences
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Bumping package version again because the previous version was published with the wrong content due to a failure in the publish workflow.