### PR TITLE
Wrap searched display name as a string

### DIFF
--- a/audiences-react/docs/CHANGELOG.md
+++ b/audiences-react/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Wrap SCIM resource typeahead search as a string [#308](https://github.com/powerhome/audiences/pull/308)
+
 # Version 1.0.2 (2024-04-30)
 
 - Build for ES2018 to remove nullish coalescing operator from final build [#293](https://github.com/powerhome/audiences/pull/293)

--- a/audiences-react/src/scim.ts
+++ b/audiences-react/src/scim.ts
@@ -11,7 +11,7 @@ export function useScim(): UseScimResources {
   const { get } = useFetch(uri)
 
   const filter = async (resourceId: string, displayName: string) => {
-    return await get(`${resourceId}?filter=displayName co ${displayName}`)
+    return await get(`${resourceId}?filter=displayName co "${displayName}"`)
   }
 
   return { filter }


### PR DESCRIPTION
In SCIM filters, strings should be wrapped in quotes. This PR fixes these filters.