### PR TITLE
Fix postgresql known issues

### DIFF
--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -10,7 +10,8 @@ module Audiences
       attrs = resources.map do |data|
         { user_id: data["id"], data: data, created_at: Time.current, updated_at: Time.current }
       end
-      upsert_all(attrs) # rubocop:disable Rails/SkipsModelValidations
+      unique_by = :user_id if connection.supports_insert_conflict_target?
+      upsert_all(attrs, unique_by: unique_by) # rubocop:disable Rails/SkipsModelValidations
       where(user_id: attrs.pluck(:user_id))
     end
 

--- a/audiences/app/models/audiences/users_search.rb
+++ b/audiences/app/models/audiences/users_search.rb
@@ -27,7 +27,14 @@ module Audiences
   private
 
     def result
-      @result ||= @scope.where("data LIKE ?", "%#{@query}%")
+      @result ||= @scope.where("#{data_attribute_query} LIKE ?", "%#{@query}%")
+    end
+
+    def data_attribute_query
+      case @scope.connection.adapter_name
+      when "PostgreSQL" then "CAST(data AS TEXT)"
+      else "CAST(data AS CHAR)"
+      end
     end
   end
 end

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix PostgreSQL compability [#312](https://github.com/powerhome/audiences/pull/312)
+
 # Version 1.0.2 (2024-04-30)
 
 - Fix mysql2 compability – drop sqlite3 [#292](https://github.com/powerhome/audiences/pull/292)

--- a/audiences/spec/models/audiences/external_user_spec.rb
+++ b/audiences/spec/models/audiences/external_user_spec.rb
@@ -26,13 +26,12 @@ RSpec.describe Audiences::ExternalUser, :aggregate_failures do
 
     it "updates existing users" do
       joseph = Audiences::ExternalUser.create(user_id: 456, data: { "id" => 456, displayName: "Joseph F. Doe" })
+      user_data = [
+        { "id" => 123, "displayName" => "John Doe" },
+        { "id" => 456, "displayName" => "Joseph Doe" },
+      ]
 
-      john, updated_joseph, *others = Audiences::ExternalUser.wrap([
-                                                                     { "id" => 123,
-                                                                       "displayName" => "John Doe" },
-                                                                     { "id" => 456,
-                                                                       "displayName" => "Joseph Doe" },
-                                                                   ])
+      john, updated_joseph, *others = Audiences::ExternalUser.wrap(user_data).order(:user_id)
 
       expect(others).to be_empty
       expect(john.user_id).to eql "123"

--- a/audiences/spec/models/audiences/external_user_spec.rb
+++ b/audiences/spec/models/audiences/external_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Audiences::ExternalUser do
+RSpec.describe Audiences::ExternalUser, :aggregate_failures do
   describe "#map" do
     it "takes a list of user data and creates ExternalUser instances, returning them" do
       john, joseph, mary, steve, *others = Audiences::ExternalUser.wrap([

--- a/audiences/spec/models/audiences/user_search_spec.rb
+++ b/audiences/spec/models/audiences/user_search_spec.rb
@@ -4,8 +4,14 @@ require "rails_helper"
 
 RSpec.describe Audiences::UsersSearch do
   it "searches through any serialized data attribute" do
-    john_doe = Audiences::ExternalUser.create(user_id: 123, data: { name: "John Doe" })
-    frank_doe = Audiences::ExternalUser.create(user_id: 321, data: { name: "Frank Doe", territory: "Philadelphia" })
+    john_doe = Audiences::ExternalUser.create(
+      user_id: 123,
+      data: { displayName: "John Doe" }
+    )
+    frank_doe = Audiences::ExternalUser.create(
+      user_id: 321,
+      data: { displayName: "Frank Doe", territory: "Philadelphia" }
+    )
 
     john_search = Audiences::UsersSearch.new(query: "John")
     phila_search = Audiences::UsersSearch.new(query: "Phila")


### PR DESCRIPTION
Fixes known issues on PostgreSQL. These fixes have been validated on https://github.com/powerhome/audiences/pull/307. The build including PostgreSQL is bein prepared on that PR, but have been cherry-picked here to unblock users of Audiences.

- **Use unique_by when needed**
- **Aggregate failures**
- **Assert on ordered data**
- **Allow user search on multiple adapters**
