### PR TITLE
Adjust user id to SCIM Protocol

### DIFF
--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -44,7 +44,7 @@ module Audiences
       params.permit(
         :match_all,
         criteria: [groups: {}],
-        extra_users: [:id, :displayName, { photos: %i[type value] }]
+        extra_users: [:externalId, :displayName, { photos: %i[type value] }]
       ).to_h.symbolize_keys
     end
   end

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -8,7 +8,7 @@ module Audiences
       return [] unless resources&.any?
 
       attrs = resources.map do |data|
-        { user_id: data["id"], data: data, created_at: Time.current, updated_at: Time.current }
+        { user_id: data["externalId"], data: data, created_at: Time.current, updated_at: Time.current }
       end
       unique_by = :user_id if connection.supports_insert_conflict_target?
       upsert_all(attrs, unique_by: unique_by) # rubocop:disable Rails/SkipsModelValidations

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Adjust user id to SCIM Protocol [#356](https://github.com/powerhome/audiences/pull/356)
+
 # Version 1.1.2 (2024-06-18)
 
 - Ignore empty groups in criterion [#354](https://github.com/powerhome/audiences/pull/354)

--- a/audiences/lib/audiences/scim.rb
+++ b/audiences/lib/audiences/scim.rb
@@ -6,7 +6,7 @@ require_relative "scim/resources_query"
 module Audiences
   module Scim
     mattr_accessor :client
-    mattr_accessor :defaults, default: Hash.new(attributes: "id,displayName")
+    mattr_accessor :defaults, default: Hash.new(attributes: "id,externalId,displayName")
 
   module_function
 

--- a/audiences/spec/dummy/config/initializers/audiences.rb
+++ b/audiences/spec/dummy/config/initializers/audiences.rb
@@ -5,7 +5,7 @@ Audiences::Scim.client = Audiences::Scim::Client.new(
   headers: { "Authorization" => ENV.fetch("SCIM_AUTHORIZATION", "Bearer 123456789") }
 )
 
-Audiences::Scim.defaults[:Users] = { attributes: "id,displayName,photos" }
+Audiences::Scim.defaults[:Users] = { attributes: "id,externalId,displayName,photos" }
 
 Rails.application.config.to_prepare do
   Audiences::Notifications.subscribe ExampleOwner, job: UpdateMembershipsJob

--- a/audiences/spec/lib/audiences/scim_spec.rb
+++ b/audiences/spec/lib/audiences/scim_spec.rb
@@ -15,19 +15,13 @@ RSpec.describe Audiences::Scim do
     it "applies the default attributes if no default is set" do
       query = Audiences::Scim.resources(type: :Anything)
 
-      expect(query.query_options).to eql({ attributes: "id,displayName" })
+      expect(query.query_options).to eql({ attributes: "id,externalId,displayName" })
     end
   end
 
   describe ".defaults" do
     it "limits the attributes to id and displayName by default" do
-      expect(Audiences::Scim.defaults[:Anything]).to eql({ attributes: "id,displayName" })
-    end
-
-    it "allows to override for specific resources" do
-      Audiences::Scim.defaults[:Users] = { attributes: "id,displayName,photos" }
-
-      expect(Audiences::Scim.defaults[:Users]).to eql({ attributes: "id,displayName,photos" })
+      expect(Audiences::Scim.defaults[:Anything]).to eql({ attributes: "id,externalId,displayName" })
     end
   end
 end

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Audiences do
     let(:token) { Audiences.sign(baseball_club) }
 
     it "updates an audience context from a given key and params" do
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
         .with(query: {})
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
 
@@ -29,24 +29,24 @@ RSpec.describe Audiences do
     end
 
     it "updates an direct resources collection" do
-      updated_context = Audiences.update(token, extra_users: [{ id: 678 }])
-      expect(updated_context.extra_users).to eql([{ "id" => 678 }])
+      updated_context = Audiences.update(token, extra_users: [{ externalId: 678 }])
+      expect(updated_context.extra_users).to eql([{ "externalId" => 678 }])
 
-      updated_context = Audiences.update(token, extra_users: [{ id: 123 }, { id: 321 }])
-      expect(updated_context.extra_users).to eql([{ "id" => 123 }, { "id" => 321 }])
+      updated_context = Audiences.update(token, extra_users: [{ externalId: 123 }, { externalId: 321 }])
+      expect(updated_context.extra_users).to eql([{ "externalId" => 123 }, { "externalId" => 321 }])
     end
 
     it "updates group criterion" do
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
         .with(query: { filter: "groups.value eq 1 OR groups.value eq 2" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
         .with(query: { filter: "groups.value eq 3 OR groups.value eq 4" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
         .with(query: { filter: "groups.value eq 5 OR groups.value eq 6" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
         .with(query: { filter: "groups.value eq 7 OR groups.value eq 8" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
 

--- a/audiences/spec/models/audiences/context_users_spec.rb
+++ b/audiences/spec/models/audiences/context_users_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Audiences::ContextUsers do
     end
 
     it "includes the extra users uniquely" do
-      criterion = Audiences::Criterion.new(users: [external_user!("externalId" => 1), external_user!("externalId" => 2)])
+      criterion = Audiences::Criterion.new(users: [external_user!("externalId" => 1),
+                                                   external_user!("externalId" => 2)])
       context = Audiences::Context.new(
         match_all: false,
         criteria: [criterion],

--- a/audiences/spec/models/audiences/context_users_spec.rb
+++ b/audiences/spec/models/audiences/context_users_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Audiences::ContextUsers do
     it "is the list of all users from SCIM when match_all" do
       response = {
         "Resources" => [
-          { "id" => 1313 },
-          { "id" => 1414 },
+          { "externalId" => 1313 },
+          { "externalId" => 1414 },
         ],
       }
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
         .to_return(status: 200, body: response.to_json)
 
       context = Audiences::Context.new(match_all: true)
@@ -25,9 +25,9 @@ RSpec.describe Audiences::ContextUsers do
 
   context "has criteria" do
     it "is the distinct union of users from the criteria" do
-      user1 = external_user!("id" => 1)
-      user2 = external_user!("id" => 2)
-      user3 = external_user!("id" => 3)
+      user1 = external_user!("externalId" => 1)
+      user2 = external_user!("externalId" => 2)
+      user3 = external_user!("externalId" => 3)
 
       criterion1 = Audiences::Criterion.new(users: [user1, user2])
       criterion2 = Audiences::Criterion.new(users: [user2, user3])
@@ -39,11 +39,11 @@ RSpec.describe Audiences::ContextUsers do
     end
 
     it "includes the extra users uniquely" do
-      criterion = Audiences::Criterion.new(users: [external_user!("id" => 1), external_user!("id" => 2)])
+      criterion = Audiences::Criterion.new(users: [external_user!("externalId" => 1), external_user!("externalId" => 2)])
       context = Audiences::Context.new(
         match_all: false,
         criteria: [criterion],
-        extra_users: [{ "id" => 1 }, { "id" => 456 }, { "id" => 789 }]
+        extra_users: [{ "externalId" => 1 }, { "externalId" => 456 }, { "externalId" => 789 }]
       )
 
       users = Audiences::ContextUsers.new(context).to_a
@@ -57,6 +57,6 @@ RSpec.describe Audiences::ContextUsers do
   end
 
   def external_user!(**data)
-    Audiences::ExternalUser.create(user_id: data["id"], data: data)
+    Audiences::ExternalUser.create(user_id: data["externalId"], data: data)
   end
 end

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Audiences::Criterion do
     let(:context) { Audiences::Context.for(owner) }
 
     it "fetches the criteria matching users" do
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos&filter=groups.value eq 123")
+      attrs = "id,externalId,displayName,photos"
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}&filter=groups.value eq 123")
         .to_return(status: 200, body: { "Resources" => [{ "externalId" => 13 }] }.to_json)
 
       criterion = context.criteria.create!(groups: { Departments: [{ id: 123 }] })

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Audiences::Criterion do
     let(:context) { Audiences::Context.for(owner) }
 
     it "fetches the criteria matching users" do
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos&filter=groups.value eq 123")
-        .to_return(status: 200, body: { "Resources" => [{ "id" => 13 }] }.to_json)
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos&filter=groups.value eq 123")
+        .to_return(status: 200, body: { "Resources" => [{ "externalId" => 13 }] }.to_json)
 
       criterion = context.criteria.create!(groups: { Departments: [{ id: 123 }] })
 

--- a/audiences/spec/models/audiences/criterion_users_spec.rb
+++ b/audiences/spec/models/audiences/criterion_users_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Audiences::CriterionUsers do
     criterion = { Departments: [{ "id" => 1 }, { "id" => 3 }] }
     response = {
       "Resources" => [
-        { "id" => 1313 },
-        { "id" => 1414 },
+        { "externalId" => 1313 },
+        { "externalId" => 1414 },
       ],
     }
 
-    stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos" \
+    stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
                        "&filter=groups.value eq 1 OR groups.value eq 3")
       .to_return(status: 200, body: response.to_json)
 
@@ -31,23 +31,23 @@ RSpec.describe Audiences::CriterionUsers do
       }
       response1or3 = {
         "Resources" => [
-          { "id" => 1313 },
-          { "id" => 1414 },
-          { "id" => 1515 },
+          { "externalId" => 1313 },
+          { "externalId" => 1414 },
+          { "externalId" => 1515 },
         ],
       }
       response5or6 = {
         "Resources" => [
-          { "id" => 1313 },
-          { "id" => 1515 },
-          { "id" => 1516 },
+          { "externalId" => 1313 },
+          { "externalId" => 1515 },
+          { "externalId" => 1516 },
         ],
       }
 
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos" \
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
                          "&filter=groups.value eq 1 OR groups.value eq 3")
         .to_return(status: 200, body: response1or3.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos" \
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
                          "&filter=groups.value eq 5 OR groups.value eq 6")
         .to_return(status: 200, body: response5or6.to_json)
 
@@ -65,24 +65,24 @@ RSpec.describe Audiences::CriterionUsers do
       }
       response1or3 = {
         "Resources" => [
-          { "id" => 1313 },
-          { "id" => 1414 },
-          { "id" => 1515 },
+          { "externalId" => 1313 },
+          { "externalId" => 1414 },
+          { "externalId" => 1515 },
         ],
       }
       response_no_filter = {
         "Resources" => [
-          { "id" => 1313 },
-          { "id" => 1515 },
-          { "id" => 1516 },
+          { "externalId" => 1313 },
+          { "externalId" => 1515 },
+          { "externalId" => 1516 },
         ],
       }
 
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos" \
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
                          "&filter=groups.value eq 1 OR groups.value eq 3")
         .to_return(status: 200, body: response1or3.to_json)
 
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,displayName,photos&filter=")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos&filter=")
         .to_return(status: 200, body: response_no_filter.to_json)
 
       users = Audiences::CriterionUsers.new(criterion).to_a

--- a/audiences/spec/models/audiences/external_user_spec.rb
+++ b/audiences/spec/models/audiences/external_user_spec.rb
@@ -6,11 +6,14 @@ RSpec.describe Audiences::ExternalUser, :aggregate_failures do
   describe "#map" do
     it "takes a list of user data and creates ExternalUser instances, returning them" do
       john, joseph, mary, steve, *others = Audiences::ExternalUser.wrap([
-                                                                          { "externalId" => 123, "displayName" => "John Doe" },
+                                                                          { "externalId" => 123,
+                                                                            "displayName" => "John Doe" },
                                                                           { "externalId" => 456,
                                                                             "displayName" => "Joseph Doe" },
-                                                                          { "externalId" => 789, "displayName" => "Mary Doe" },
-                                                                          { "externalId" => 987, "displayName" => "Steve Doe" },
+                                                                          { "externalId" => 789,
+                                                                            "displayName" => "Mary Doe" },
+                                                                          { "externalId" => 987,
+                                                                            "displayName" => "Steve Doe" },
                                                                         ])
 
       expect(others).to be_empty

--- a/audiences/spec/models/audiences/external_user_spec.rb
+++ b/audiences/spec/models/audiences/external_user_spec.rb
@@ -6,40 +6,40 @@ RSpec.describe Audiences::ExternalUser, :aggregate_failures do
   describe "#map" do
     it "takes a list of user data and creates ExternalUser instances, returning them" do
       john, joseph, mary, steve, *others = Audiences::ExternalUser.wrap([
-                                                                          { "id" => 123, "displayName" => "John Doe" },
-                                                                          { "id" => 456,
+                                                                          { "externalId" => 123, "displayName" => "John Doe" },
+                                                                          { "externalId" => 456,
                                                                             "displayName" => "Joseph Doe" },
-                                                                          { "id" => 789, "displayName" => "Mary Doe" },
-                                                                          { "id" => 987, "displayName" => "Steve Doe" },
+                                                                          { "externalId" => 789, "displayName" => "Mary Doe" },
+                                                                          { "externalId" => 987, "displayName" => "Steve Doe" },
                                                                         ])
 
       expect(others).to be_empty
       expect(john.user_id).to eql "123"
-      expect(john.data).to match({ "id" => 123, "displayName" => "John Doe" })
+      expect(john.data).to match({ "externalId" => 123, "displayName" => "John Doe" })
       expect(joseph.user_id).to eql "456"
-      expect(joseph.data).to match({ "id" => 456, "displayName" => "Joseph Doe" })
+      expect(joseph.data).to match({ "externalId" => 456, "displayName" => "Joseph Doe" })
       expect(mary.user_id).to eql "789"
-      expect(mary.data).to match({ "id" => 789, "displayName" => "Mary Doe" })
+      expect(mary.data).to match({ "externalId" => 789, "displayName" => "Mary Doe" })
       expect(steve.user_id).to eql "987"
-      expect(steve.data).to match({ "id" => 987, "displayName" => "Steve Doe" })
+      expect(steve.data).to match({ "externalId" => 987, "displayName" => "Steve Doe" })
     end
 
     it "updates existing users" do
-      joseph = Audiences::ExternalUser.create(user_id: 456, data: { "id" => 456, displayName: "Joseph F. Doe" })
+      joseph = Audiences::ExternalUser.create(user_id: 456, data: { "externalId" => 456, displayName: "Joseph F. Doe" })
       user_data = [
-        { "id" => 123, "displayName" => "John Doe" },
-        { "id" => 456, "displayName" => "Joseph Doe" },
+        { "externalId" => 123, "displayName" => "John Doe" },
+        { "externalId" => 456, "displayName" => "Joseph Doe" },
       ]
 
       john, updated_joseph, *others = Audiences::ExternalUser.wrap(user_data).order(:user_id)
 
       expect(others).to be_empty
       expect(john.user_id).to eql "123"
-      expect(john.data).to match({ "id" => 123, "displayName" => "John Doe" })
+      expect(john.data).to match({ "externalId" => 123, "displayName" => "John Doe" })
 
       expect(updated_joseph).to eql joseph.reload
       expect(updated_joseph.user_id).to eql "456"
-      expect(updated_joseph.data).to match({ "id" => 456, "displayName" => "Joseph Doe" })
+      expect(updated_joseph.data).to match({ "externalId" => 456, "displayName" => "Joseph Doe" })
     end
   end
 end

--- a/audiences/spec/requests/scim_proxy_spec.rb
+++ b/audiences/spec/requests/scim_proxy_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe "/audiences/scim" do
   let(:resources) do
     [
-      { id: "1", displayName: "A Name", photos: "photo 1" },
-      { id: "2", displayName: "Another Name", photos: "photo 2" },
-      { id: "3", displayName: "YAN", photos: "photo 3" },
+      { externalId: "1", displayName: "A Name", photos: "photo 1" },
+      { externalId: "2", displayName: "Another Name", photos: "photo 2" },
+      { externalId: "3", displayName: "YAN", photos: "photo 3" },
     ].as_json
   end
   let(:response_body) do
@@ -16,15 +16,15 @@ RSpec.describe "/audiences/scim" do
 
   context "GET /audiences/scim" do
     it "returns the Resources key from the response" do
-      stub_request(:get, "http://example.com/scim/v2/MyResources?attributes=id,displayName&filter=name eq John")
+      stub_request(:get, "http://example.com/scim/v2/MyResources?attributes=id,externalId,displayName&filter=name eq John")
         .to_return(status: 200, body: response_body, headers: {})
 
       get audience_scim_proxy_path(scim_path: "MyResources", filter: "name eq John")
 
       expect(response.parsed_body).to match([
-                                              { "displayName" => "A Name", "id" => "1", "photos" => "photo 1" },
-                                              { "displayName" => "Another Name", "id" => "2", "photos" => "photo 2" },
-                                              { "displayName" => "YAN", "id" => "3", "photos" => "photo 3" },
+                                              { "displayName" => "A Name", "externalId" => "1", "photos" => "photo 1" },
+                                              { "displayName" => "Another Name", "externalId" => "2", "photos" => "photo 2" },
+                                              { "displayName" => "YAN", "externalId" => "3", "photos" => "photo 3" },
                                             ])
     end
   end

--- a/audiences/spec/requests/scim_proxy_spec.rb
+++ b/audiences/spec/requests/scim_proxy_spec.rb
@@ -16,14 +16,16 @@ RSpec.describe "/audiences/scim" do
 
   context "GET /audiences/scim" do
     it "returns the Resources key from the response" do
-      stub_request(:get, "http://example.com/scim/v2/MyResources?attributes=id,externalId,displayName&filter=name eq John")
+      attrs = "id,externalId,displayName"
+      stub_request(:get, "http://example.com/scim/v2/MyResources?attributes=#{attrs}&filter=name eq John")
         .to_return(status: 200, body: response_body, headers: {})
 
       get audience_scim_proxy_path(scim_path: "MyResources", filter: "name eq John")
 
       expect(response.parsed_body).to match([
                                               { "displayName" => "A Name", "externalId" => "1", "photos" => "photo 1" },
-                                              { "displayName" => "Another Name", "externalId" => "2", "photos" => "photo 2" },
+                                              { "displayName" => "Another Name", "externalId" => "2",
+                                                "photos" => "photo 2" },
                                               { "displayName" => "YAN", "externalId" => "3", "photos" => "photo 3" },
                                             ])
     end


### PR DESCRIPTION
The `externalId` is what should map the SCIM User to the system user ID. The SCIM `id` is actually the internal id of a user in the SCIM server.
