### PR TITLE
Audiences.config/configure helpers

### DIFF
--- a/audiences/app/controllers/audiences/scim_proxy_controller.rb
+++ b/audiences/app/controllers/audiences/scim_proxy_controller.rb
@@ -3,10 +3,8 @@
 module Audiences
   class ScimProxyController < ApplicationController
     def get
-      resources = Audiences::Scim.query(
-        type: params[:scim_path].to_sym,
-        filter: params[:filter]
-      )
+      resources = Audiences::Scim.resource(params[:scim_path].to_sym)
+                                 .query(filter: params[:filter])
 
       render json: resources
     end

--- a/audiences/app/controllers/audiences/scim_proxy_controller.rb
+++ b/audiences/app/controllers/audiences/scim_proxy_controller.rb
@@ -3,7 +3,7 @@
 module Audiences
   class ScimProxyController < ApplicationController
     def get
-      resources = Audiences::Scim.resources(
+      resources = Audiences::Scim.query(
         type: params[:scim_path].to_sym,
         filter: params[:filter]
       )

--- a/audiences/app/models/audiences/context_users.rb
+++ b/audiences/app/models/audiences/context_users.rb
@@ -20,7 +20,7 @@ module Audiences
   private
 
     def all_users
-      users = Scim.query(type: :Users)
+      users = Scim.resource(:Users).query
       ExternalUser.wrap(users.all)
     end
 

--- a/audiences/app/models/audiences/context_users.rb
+++ b/audiences/app/models/audiences/context_users.rb
@@ -20,7 +20,7 @@ module Audiences
   private
 
     def all_users
-      users = Scim.resources(type: :Users)
+      users = Scim.query(type: :Users)
       ExternalUser.wrap(users.all)
     end
 

--- a/audiences/app/models/audiences/criterion_users.rb
+++ b/audiences/app/models/audiences/criterion_users.rb
@@ -21,7 +21,7 @@ module Audiences
 
     def groups_users(group_ids)
       filter = group_ids.map { "groups.value eq #{_1}" }.join(" OR ")
-      users = Audiences::Scim.resources(type: :Users, filter: filter)
+      users = Audiences::Scim.query(type: :Users, filter: filter)
       ExternalUser.wrap(users.all)
     end
   end

--- a/audiences/app/models/audiences/criterion_users.rb
+++ b/audiences/app/models/audiences/criterion_users.rb
@@ -21,7 +21,7 @@ module Audiences
 
     def groups_users(group_ids)
       filter = group_ids.map { "groups.value eq #{_1}" }.join(" OR ")
-      users = Audiences::Scim.query(type: :Users, filter: filter)
+      users = Audiences::Scim.resource(:Users).query(filter: filter)
       ExternalUser.wrap(users.all)
     end
   end

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Audiences.config/configure helpers [#359](https://github.com/powerhome/audiences/pull/359)
 - Adjust user id to SCIM Protocol [#356](https://github.com/powerhome/audiences/pull/356)
 
 # Version 1.1.2 (2024-06-18)

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -2,56 +2,6 @@
 
 "Audiences" is a SCIM-integrated notifier for real-time Rails actions based on group changes.
 
-## Usage
-
-### Creating/Managing audiences
-
-An audience is tied to an owning model withing your application. For the rest of this document we're going to assume a model Team. To create audiences for a team, using `audiences-react`, you'll render an audiences editor for your model.
-
-That can be done with a unobstrusive JS renderer like react-rails, or a custom one as in [our dummy app](../audiences/spec/dummy/app/frontend/entrypoints/application.js). The editor will need two arguments:
-
-- The context URI: `audience_context_url(owner)` helper
-- The SCIM endpoint: `audience_scim_proxy_url` helper if using the [proxy](#configuring-the-scim-proxy), or the SCIM endpoint.
-
-### Configuring the SCIM backend
-
-The Audience::Scim should point to the real SCIM endpoint. The service allows you to configure the endpoint and the credentials/headers:
-
-I.e.:
-
-```ruby
-Audiences::Scim.client = Audiences::Scim::Client.new(
-  uri: ENV.fetch("SCIM_V2_API"),
-  headers: { "Authorization" => "Bearer #{ENV.fetch('SCIM_V2_TOKEN')}" }
-)
-```
-
-### Listening to audience changes
-
-The goal of audiences is to allow the app to keep up with a mutable group of people. To allow that, `Audiences` includes the `Audiences::Notifications` module, to allow the hosting app to subscribe to audiences related to a certain owner type, and react to that through a block:
-
-```ruby
-Rails.application.config.to_prepare do
-  Audiences::Notifications.subscribe Team do |context|
-    team.update_memberships(context.users)
-  end
-end
-```
-
-or scheduling an AcitiveJob:
-
-```ruby
-Rails.application.config.to_prepare do
-  Audiences::Notifications.subscribe Group, job: UpdateGroupMembershipsJob
-  Audiences::Notifications.subscribe Team, job: UpdateTeamMembershipsJob.set(queue: "low")
-end
-```
-
-You can find a working example in our dummy app:
-
-- [initializer](../spec/dummy/config/initializers/audiences.rb)
-- [job class](../spec/dummy/app/jobs/update_memberships_job.rb)
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -70,6 +20,76 @@ Or install it yourself as:
 
 ```bash
 $ gem install audiences
+```
+
+## Usage
+
+### Creating/Managing audiences
+
+An audience is tied to an owning model withing your application. For the rest of this document we're going to assume a model Team. To create audiences for a team, using `audiences-react`, you'll render an audiences editor for your model.
+
+That can be done with a unobstrusive JS renderer like react-rails, or a custom one as in [our dummy app](../audiences/spec/dummy/app/frontend/entrypoints/application.js). The editor will need two arguments:
+
+- The context URI: `audience_context_url(owner)` helper
+- The SCIM endpoint: `audience_scim_proxy_url` helper if using the [proxy](#configuring-the-scim-proxy), or the SCIM endpoint.
+
+### Configuring Audiences
+
+The Audience::Scim should point to the SCIM endpoint. The service allows you to configure the endpoint and the credentials/headers:
+
+I.e.:
+
+```ruby
+Audiences.configure do |config|
+  config.scim = {
+    uri: ENV.fetch("SCIM_V2_API"),
+    headers: { "Authorization" => "Bearer #{ENV.fetch('SCIM_V2_TOKEN')}" }
+  }
+end
+```
+
+#### Listening to audience changes
+
+The goal of audiences is to allow the app to keep up with a mutable group of people. To allow that, `Audiences` allows the hosting app to subscribe to audiences related to a certain owner type, and react to that through a block:
+
+```ruby
+Audiences.configure do |config|
+  config.notifications do
+    subscribe Team do |context|
+      team.update_memberships(context.users)
+    end
+  end
+end
+```
+
+or scheduling an AcitiveJob:
+
+```ruby
+Audiences.configure do |config|
+  config.notifications do
+    subscribe Group, job: UpdateGroupMembershipsJob
+    subscribe Team, job: UpdateTeamMembershipsJob.set(queue: "low")
+  end
+end
+```
+
+Notice that the notifications block is executed every time the app is loaded or reloaded, through a `to_prepare` block. This allows autoloaded constants such as model and job classes to be referenced.
+
+You can find a working example in our dummy app:
+
+- [initializer](../spec/dummy/config/initializers/audiences.rb)
+- [job class](../spec/dummy/app/jobs/update_memberships_job.rb)
+- [example owning model](../spec/dummy/app/models/example_owner.rb.rb)
+
+#### SCIM resource attributes
+
+You can configure which attributes are going to be requested to the SCIM backend for each resource type. Audiences requires that at least `id` and `displayName` are requested, and also requests `photos` for users by default. But you might want to request extra attributes to use them directly from `Audiences::ExternalUser`. This is possible using the `resource` configuration helper:
+
+```ruby
+Audiences.configure do |config|
+  config.resource :Users, attributes: "id,displayName,photos,name"
+  config.resource :Groups, attributes: "id,displayName,mfaRequired"
+end
 ```
 
 ## Contributing

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require "audiences/version"
-require "audiences/scim"
-require "audiences/notifications"
-
 # Audiences system
 # Audiences pushes notifications to your rails app when a
 # SCIM backend updates a user, notifying matching audiences.
 #
 module Audiences
+  autoload :Notifications, "audiences/notifications"
+  autoload :Scim, "audiences/scim"
+  autoload :VERSION, "audiences/version"
+
   GID_RESOURCE = "audiences"
 
 module_function
@@ -59,3 +59,5 @@ module_function
     ::Audiences::Context.for(owner).tap(&block)
   end
 end
+
+require "audiences/configuration"

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -5,6 +5,13 @@ module Audiences
 
   # Configuration options
   config_accessor :scim
+  config_accessor :resources do
+    { Users: Scim::Resource.new(type: :Users, attributes: "id,externalId,displayName,photos") }
+  end
+
+  def config.resource(type:, **kwargs)
+    config.resources[type] = Scim::Resource.new(type: type, **kwargs)
+  end
 
   def config.notifications(&block)
     Rails.application.config.to_prepare do

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -4,15 +4,67 @@ module Audiences
   include ActiveSupport::Configurable
 
   # Configuration options
+
+  #
+  # SCIM service configurations. This should be a Hash containint, at least, the URI.
+  #
+  # I.e.:
+  #
+  #   Audiences.configure do |config|
+  #     config.scim = { uri: "http://localhost/api/scim" }
+  #   end
+  #
+  # It can also contain HTTP headers, such as "Authorization":
+  #
+  # I.e.:
+  #
+  #   Audiences.configure do |config|
+  #     config.scim = {
+  #       uri: "http://localhost/api/scim",
+  #       headers: { "Authorization" => "Bearer auth-token" }
+  #     }
+  #   end
+  #
   config_accessor :scim
+
+  #
+  # Resources defaults. Change this configuration via the `resource` helper.
+  # This configuration lists the current Audiences accessible resource defaults,
+  # and defaults to Users only. To add other resource types for criteria building.
+  #
+  # @see `resource`.
+  #
   config_accessor :resources do
     { Users: Scim::Resource.new(type: :Users, attributes: "id,externalId,displayName,photos") }
   end
 
+  #
+  # Configures a resource default.
+  #
+  # @param type [Symbol] the resource type in plural, as in scim (i.e.: :Users)
+  # @param attributes [String] the list of attributes to fetch for the resource (i.e.: "id,externalId,displayName")
+  # @see [Audiences::Scim::Resource]
   def config.resource(type:, **kwargs)
     config.resources[type] = Scim::Resource.new(type: type, **kwargs)
   end
 
+  #
+  # Notifications configurations.
+  # Within this block, you should be able to easily register job classes to execute as
+  # audiences are changed. Notice: this block is executed every time your app initializes
+  # or reloads. This allows you to reference reloaded constants, like job names:
+  #
+  # I.e.:
+  #
+  #   Audiences.configure do |config|
+  #     config.notifications do
+  #       subscribe CallQueue, job: CallQueueMembersSyncJob
+  #       subscribe ChatRoom, job: ChatRoomMembersSyncJob
+  #     end
+  #   end
+  #
+  # This block is executed
+  # @see [Audiences::Notifications]
   def config.notifications(&block)
     Rails.application.config.to_prepare do
       Notifications.class_eval(&block)

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Audiences
+  include ActiveSupport::Configurable
+
+  # Configuration options
+  config_accessor :scim
+
+  def config.notifications(&block)
+    Rails.application.config.to_prepare do
+      Notifications.class_eval(&block)
+    end
+  end
+end

--- a/audiences/lib/audiences/scim.rb
+++ b/audiences/lib/audiences/scim.rb
@@ -5,10 +5,13 @@ require_relative "scim/resources_query"
 
 module Audiences
   module Scim
-    mattr_accessor :client
     mattr_accessor :defaults, default: Hash.new(attributes: "id,externalId,displayName")
 
   module_function
+
+    def client
+      Client.new(**Audiences.config.scim)
+    end
 
     def query(type:, client: Scim.client, **options)
       options = (defaults[type] || {}).merge(options)

--- a/audiences/lib/audiences/scim.rb
+++ b/audiences/lib/audiences/scim.rb
@@ -10,7 +10,7 @@ module Audiences
 
   module_function
 
-    def resources(type:, client: Scim.client, **options)
+    def query(type:, client: Scim.client, **options)
       options = (defaults[type] || {}).merge(options)
 
       ResourcesQuery.new(client, resource_type: type, **options)

--- a/audiences/lib/audiences/scim.rb
+++ b/audiences/lib/audiences/scim.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "scim/client"
-require_relative "scim/resources_query"
-
 module Audiences
   module Scim
-    mattr_accessor :defaults, default: Hash.new(attributes: "id,externalId,displayName")
+    autoload :Client, "audiences/scim/client"
+    autoload :Resource, "audiences/scim/resource"
+    autoload :ResourcesQuery, "audiences/scim/resources_query"
 
   module_function
 
@@ -13,10 +12,10 @@ module Audiences
       Client.new(**Audiences.config.scim)
     end
 
-    def query(type:, client: Scim.client, **options)
-      options = (defaults[type] || {}).merge(options)
-
-      ResourcesQuery.new(client, resource_type: type, **options)
+    def resource(type, **options)
+      Audiences.config.resources.fetch(type) do
+        Resource.new(type: type, **options)
+      end
     end
   end
 end

--- a/audiences/lib/audiences/scim/resource.rb
+++ b/audiences/lib/audiences/scim/resource.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Audiences
+  module Scim
+    class Resource
+      attr_accessor :options, :type
+
+      def initialize(type:, attributes: "id,externalId,displayName", **options)
+        @type = type
+        @options = options
+        @options[:attributes] = attributes
+      end
+
+      def query(**options)
+        ResourcesQuery.new(Scim.client, resource: self, **@options, **options)
+      end
+    end
+  end
+end

--- a/audiences/lib/audiences/scim/resources_query.rb
+++ b/audiences/lib/audiences/scim/resources_query.rb
@@ -9,12 +9,12 @@ module Audiences
     class ResourcesQuery
       include Enumerable
 
-      attr_reader :query_options
+      attr_reader :options, :resource
 
-      def initialize(client, resource_type:, **query_options)
+      def initialize(client, resource:, **options)
         @client = client
-        @resource_type = resource_type
-        @query_options = query_options
+        @resource = resource
+        @options = options
       end
 
       def all
@@ -53,14 +53,13 @@ module Audiences
       def next_page
         return unless next_page?
 
-        ResourcesQuery.new(@client, resource_type: @resource_type, **@query_options,
-                                    startIndex: next_index)
+        ResourcesQuery.new(@client, resource: @resource, **@options, startIndex: next_index)
       end
 
     private
 
       def response
-        @response ||= @client.perform_request(path: @resource_type, method: :Get, query: @query_options)
+        @response ||= @client.perform_request(path: @resource.type, method: :Get, query: @options)
       end
     end
   end

--- a/audiences/spec/dummy/config/initializers/audiences.rb
+++ b/audiences/spec/dummy/config/initializers/audiences.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-Audiences::Scim.client = Audiences::Scim::Client.new(
-  uri: ENV.fetch("SCIM_V2_API", "http://example.com/scim/v2/"),
-  headers: { "Authorization" => ENV.fetch("SCIM_AUTHORIZATION", "Bearer 123456789") }
-)
+Audiences.configure do |config|
+  config.scim = {
+    uri: ENV.fetch("SCIM_V2_API", "http://example.com/scim/v2/"),
+    headers: { "Authorization" => ENV.fetch("SCIM_AUTHORIZATION", "Bearer 123456789") }
+  }
 
-Audiences::Scim.defaults[:Users] = { attributes: "id,externalId,displayName,photos" }
-
-Rails.application.config.to_prepare do
-  Audiences::Notifications.subscribe ExampleOwner, job: UpdateMembershipsJob
+  config.subscriptions do
+    subscribe ExampleOwner, job: UpdateMembershipsJob
+  end
 end

--- a/audiences/spec/dummy/config/initializers/audiences.rb
+++ b/audiences/spec/dummy/config/initializers/audiences.rb
@@ -3,7 +3,7 @@
 Audiences.configure do |config|
   config.scim = {
     uri: ENV.fetch("SCIM_V2_API", "http://example.com/scim/v2/"),
-    headers: { "Authorization" => ENV.fetch("SCIM_AUTHORIZATION", "Bearer 123456789") }
+    headers: { "Authorization" => ENV.fetch("SCIM_AUTHORIZATION", "Bearer 123456789") },
   }
 
   config.subscriptions do

--- a/audiences/spec/lib/audiences/scim/resources_query_spec.rb
+++ b/audiences/spec/lib/audiences/scim/resources_query_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
         )
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { startIndex: 3,})
+            .with(method: :Get, path: :Users, query: { startIndex: 3 })
             .and_return("Resources" => [
                           { "id" => 333, "displayName" => "John Doe the 3rd" },
                           { "id" => 444, "displayName" => "John Doe the 4th" },
@@ -53,7 +53,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
         )
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { startIndex: 5,})
+            .with(method: :Get, path: :Users, query: { startIndex: 5 })
             .and_return("Resources" => [
                           { "id" => 555, "displayName" => "John Doe the 5th" },
                         ],
@@ -132,7 +132,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
       it "is a similar ResourcesQuery object of the next page" do
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { filters: "displayName eq John",})
+            .with(method: :Get, path: :Users, query: { filters: "displayName eq John" })
             .and_return("totalResults" => 40,
                         "startIndex" => 1,
                         "itemsPerPage" => 25)
@@ -148,7 +148,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
       it "is nil when there is no next page" do
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { startIndex: 26,})
+            .with(method: :Get, path: :Users, query: { startIndex: 26 })
             .and_return("totalResults" => 40,
                         "startIndex" => 26,
                         "itemsPerPage" => 25)

--- a/audiences/spec/lib/audiences/scim/resources_query_spec.rb
+++ b/audiences/spec/lib/audiences/scim/resources_query_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe Audiences::Scim::ResourcesQuery do
+  let(:users_resource) { Audiences::Scim::Resource.new(type: :Users) }
+  let(:groups_resource) { Audiences::Scim::Resource.new(type: :Groups) }
   let(:client) { instance_double(Audiences::Scim::Client) }
 
   describe "data fetching" do
@@ -18,7 +20,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
                       ])
       )
 
-      resources = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Groups).to_a
+      resources = Audiences::Scim::ResourcesQuery.new(client, resource: groups_resource).to_a
 
       expect(resources.size).to eql 4
       expect(resources.first["id"]).to eql 123
@@ -40,7 +42,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
         )
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { startIndex: 3 })
+            .with(method: :Get, path: :Users, query: { startIndex: 3,})
             .and_return("Resources" => [
                           { "id" => 333, "displayName" => "John Doe the 3rd" },
                           { "id" => 444, "displayName" => "John Doe the 4th" },
@@ -51,7 +53,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
         )
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { startIndex: 5 })
+            .with(method: :Get, path: :Users, query: { startIndex: 5,})
             .and_return("Resources" => [
                           { "id" => 555, "displayName" => "John Doe the 5th" },
                         ],
@@ -60,7 +62,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
                         "itemsPerPage" => 2)
         )
 
-        query = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Users)
+        query = Audiences::Scim::ResourcesQuery.new(client, resource: users_resource)
 
         expect(query.all.count).to eql 5 # rubocop:disable Rails/RedundantActiveRecordAllMethod
       end
@@ -78,7 +80,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
                         "itemsPerPage" => 25)
         )
 
-        query = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Groups)
+        query = Audiences::Scim::ResourcesQuery.new(client, resource: groups_resource)
 
         expect(query.next_page?).to be true
       end
@@ -92,7 +94,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
                         "itemsPerPage" => 2)
         )
 
-        query = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Groups)
+        query = Audiences::Scim::ResourcesQuery.new(client, resource: groups_resource)
 
         expect(query.next_page?).to be true
       end
@@ -106,7 +108,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
                         "itemsPerPage" => 25)
         )
 
-        query = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Groups)
+        query = Audiences::Scim::ResourcesQuery.new(client, resource: groups_resource)
 
         expect(query.next_page?).to be false
       end
@@ -120,7 +122,7 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
                         "itemsPerPage" => 25)
         )
 
-        query = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Groups)
+        query = Audiences::Scim::ResourcesQuery.new(client, resource: groups_resource)
 
         expect(query.next_page?).to be false
       end
@@ -130,28 +132,28 @@ RSpec.describe Audiences::Scim::ResourcesQuery do
       it "is a similar ResourcesQuery object of the next page" do
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { filters: "displayName eq John" })
+            .with(method: :Get, path: :Users, query: { filters: "displayName eq John",})
             .and_return("totalResults" => 40,
                         "startIndex" => 1,
                         "itemsPerPage" => 25)
         )
 
-        query = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Users, filters: "displayName eq John")
+        query = Audiences::Scim::ResourcesQuery.new(client, resource: users_resource, filters: "displayName eq John")
         next_page = query.next_page
 
-        expect(next_page.query_options.delete(:startIndex)).to eql 26
-        expect(query.query_options).to eql(next_page.query_options)
+        expect(next_page.options.delete(:startIndex)).to eql 26
+        expect(query.options).to eql(next_page.options)
       end
 
       it "is nil when there is no next page" do
         allow(client).to(
           receive(:perform_request)
-            .with(method: :Get, path: :Users, query: { startIndex: 26 })
+            .with(method: :Get, path: :Users, query: { startIndex: 26,})
             .and_return("totalResults" => 40,
                         "startIndex" => 26,
                         "itemsPerPage" => 25)
         )
-        query = Audiences::Scim::ResourcesQuery.new(client, resource_type: :Users, startIndex: 26)
+        query = Audiences::Scim::ResourcesQuery.new(client, resource: users_resource, startIndex: 26)
 
         expect(query.next_page?).to be false
         expect(query.next_page).to be_nil

--- a/audiences/spec/lib/audiences/scim_spec.rb
+++ b/audiences/spec/lib/audiences/scim_spec.rb
@@ -4,24 +4,19 @@ require "rails_helper"
 
 RSpec.describe Audiences::Scim do
   describe ".resources" do
-    it "applies the defaults to the given options" do
-      Audiences::Scim.defaults[:Test] = { attributes: "id,photos" }
+    it "fetches the resource definition by the type key" do
+      Audiences.config.resources[:Test] = Audiences::Scim::Resource.new(type: :Test, attributes: "id,photos")
 
-      query = Audiences::Scim.resources(type: :Test)
+      resource = Audiences::Scim.resource(:Test)
 
-      expect(query.query_options).to eql({ attributes: "id,photos" })
+      expect(resource.type).to be :Test
+      expect(resource.options).to match({ attributes: "id,photos" })
     end
 
-    it "applies the default attributes if no default is set" do
-      query = Audiences::Scim.resources(type: :Anything)
+    it "creates a new resource definition when one doesn't exist" do
+      resource = Audiences::Scim.resource(:Anything)
 
-      expect(query.query_options).to eql({ attributes: "id,externalId,displayName" })
-    end
-  end
-
-  describe ".defaults" do
-    it "limits the attributes to id and displayName by default" do
-      expect(Audiences::Scim.defaults[:Anything]).to eql({ attributes: "id,externalId,displayName" })
+      expect(resource.type).to be :Anything
     end
   end
 end


### PR DESCRIPTION
Introduce Audiences.config handling all Audience configurations, making adding new configuration options easier and more standardized.

Also adds helper configuration functions to context subscriptions and resource defaults.

- **Rename resources method to query**
- **Fetch client details from Audiences.config**
- **Introduce Scim::Resource to handle resource defaults**
- **Add configuration documentation**
- **Update initializer to new configuration**
- **Update documentation**

Before / After
![Audiences_config_configure_helpers](https://github.com/user-attachments/assets/29ecb4c6-2d76-458f-be7b-8486ffcefdbb)
