### PR TITLE
Audiences model helpers

### DIFF
--- a/audiences/.rubocop.yml
+++ b/audiences/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-powerhome
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - "vendor/**/*"
     - "spec/dummy/node_modules/**/*"

--- a/audiences/.rubocop.yml
+++ b/audiences/.rubocop.yml
@@ -6,11 +6,11 @@ AllCops:
   Exclude:
     - "vendor/**/*"
     - "spec/dummy/node_modules/**/*"
+    - "spec/dummy/db/schema.rb"
 
 Style/FrozenStringLiteralComment:
   Exclude:
     - "gemfiles/*"
-    - "spec/dummy/db/schema.rb"
 
 Lint/ToEnumArguments:
   Exclude:
@@ -19,18 +19,6 @@ Lint/ToEnumArguments:
 Bundler/OrderedGems:
   Exclude:
     - "gemfiles/*"
-
-Style/NumericLiterals:
-  Exclude:
-    - "spec/dummy/db/schema.rb"
-
-Style/WordArray:
-  Exclude:
-    - "spec/dummy/db/schema.rb"
-
-Layout/EmptyLinesAroundBlockBody:
-  Exclude:
-    - "spec/dummy/db/schema.rb"
 
 Rails/I18nLocaleTexts:
   Exclude:

--- a/audiences/Gemfile.lock
+++ b/audiences/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    audiences (1.1.2)
+    audiences (1.2.0)
       rails (>= 6.0)
 
 GEM

--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -3,7 +3,7 @@
 module Audiences
   class ContextsController < ApplicationController
     def show
-      render_context Audiences.load(params.require(:key))
+      render_context Audiences::Context.load(params.require(:key))
     end
 
     def update
@@ -23,7 +23,7 @@ module Audiences
   private
 
     def current_context
-      @current_context ||= Audiences.load(params.require(:key))
+      @current_context ||= Audiences::Context.load(params.require(:key))
     end
 
     def current_criterion

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -22,8 +22,8 @@ module Audiences
     #
     # @private
     # @return [Audiences::Context]
-    def self.for(owner)
-      where(owner: owner).first_or_create!
+    def self.for(owner, relation: nil)
+      where(owner: owner, relation: relation).first_or_create!
     end
 
     def refresh_users!

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -6,6 +6,7 @@ module Audiences
   # users (#criteria, #match_all, #extra_users).
   #
   class Context < ApplicationRecord
+    include Locating
     include ::Audiences::MembershipGroup
 
     belongs_to :owner, polymorphic: true
@@ -16,14 +17,6 @@ module Audiences
     before_save if: :match_all do
       self.criteria = []
       self.extra_users = []
-    end
-
-    # Finds or creates a context for the given owner
-    #
-    # @private
-    # @return [Audiences::Context]
-    def self.for(owner, relation: nil)
-      where(owner: owner, relation: relation).first_or_create!
     end
 
     def refresh_users!

--- a/audiences/app/models/audiences/context/locating.rb
+++ b/audiences/app/models/audiences/context/locating.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Audiences
+  class Context
+    module Locating
+      extend ActiveSupport::Concern
+
+      SIGNED_GID_RESOURCE = "audiences"
+
+      class_methods do
+        # Finds or creates a context for the given owner/relation
+        #
+        # @private
+        # @param owner [Class<ActiveRecord::Base>] an active record owning the context
+        # @Param relation [String,Symbol] a context relation (i.e.: :members)
+        # @return [Audiences::Context]
+        def for(owner, relation: nil)
+          where(owner: owner, relation: relation).first_or_create!
+        end
+
+        # Loads a context given a signed GlobalID key
+        #
+        # @private
+        # @param key [String] signed GlobalID key
+        # @return [Audiences::Context]
+        # @yield [Audiences::Context]
+        def load(key)
+          GlobalID::Locator.locate_signed(key, for: SIGNED_GID_RESOURCE).tap do |ctx|
+            yield ctx if block_given?
+          end
+        end
+      end
+
+      def signed_key
+        to_sgid(for: SIGNED_GID_RESOURCE)
+      end
+    end
+  end
+end

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -2,7 +2,13 @@
 
 module Audiences
   class ExternalUser < ApplicationRecord
-    has_many :memberships
+    if Audiences.config.identity_class
+      belongs_to :identity, class_name: Audiences.config.identity_class, # rubocop:disable Rails/ReflectionClassName
+                            primary_key: Audiences.config.identity_key,
+                            foreign_key: :user_id,
+                            optional: true,
+                            inverse_of: false
+    end
 
     def self.wrap(resources)
       return [] unless resources&.any?

--- a/audiences/config/routes.rb
+++ b/audiences/config/routes.rb
@@ -10,8 +10,8 @@ end
 Rails.application.routes.draw do
   mount Audiences::Engine, at: "/audiences", as: :audiences
 
-  direct :audience_context do |owner, options|
-    audiences.route_for(:signed_context, key: Audiences.sign(owner), **options)
+  direct :audience_context do |owner, relation: nil|
+    audiences.route_for(:signed_context, key: Audiences.sign(owner, relation: relation))
   end
 
   direct :audience_scim_proxy do |options|

--- a/audiences/config/routes.rb
+++ b/audiences/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   direct :audience_context do |context, relation = nil|
     context = Audiences::Context.for(context, relation: relation)
-    audiences.route_for(:signed_context, key: Audiences.sign(context))
+    audiences.route_for(:signed_context, key: context.signed_key)
   end
 
   direct :audience_scim_proxy do |options|

--- a/audiences/config/routes.rb
+++ b/audiences/config/routes.rb
@@ -8,14 +8,12 @@ Audiences::Engine.routes.draw do
 end
 
 Rails.application.routes.draw do
-  mount Audiences::Engine, at: "/audiences", as: :audiences
-
-  direct :audience_context do |context, relation = nil|
-    context = Audiences::Context.for(context, relation: relation)
-    audiences.route_for(:signed_context, key: context.signed_key)
+  direct :audience_context do |owner, relation = nil|
+    context = Audiences::Context.for(owner, relation: relation)
+    Audiences::Engine.routes.url_helpers.route_for(:signed_context, key: context.signed_key, **url_options)
   end
 
   direct :audience_scim_proxy do |options|
-    audiences.route_for(:scim_proxy, **options)
+    Audiences::Engine.routes.url_helpers.route_for(:scim_proxy, **url_options, **options)
   end
 end

--- a/audiences/config/routes.rb
+++ b/audiences/config/routes.rb
@@ -10,8 +10,9 @@ end
 Rails.application.routes.draw do
   mount Audiences::Engine, at: "/audiences", as: :audiences
 
-  direct :audience_context do |owner, relation: nil|
-    audiences.route_for(:signed_context, key: Audiences.sign(owner, relation: relation))
+  direct :audience_context do |context, relation = nil|
+    context = Audiences::Context.for(context, relation: relation)
+    audiences.route_for(:signed_context, key: Audiences.sign(context))
   end
 
   direct :audience_scim_proxy do |options|

--- a/audiences/db/migrate/20240722025634_add_relation_to_context.rb
+++ b/audiences/db/migrate/20240722025634_add_relation_to_context.rb
@@ -4,6 +4,8 @@ class AddRelationToContext < ActiveRecord::Migration[6.1]
   def change
     add_column :audiences_contexts, :relation, :string, null: true
     remove_index :audiences_contexts, %w[owner_type owner_id], unique: true
-    add_index :audiences_contexts, %w[owner_type owner_id relation], unique: true
+    add_index :audiences_contexts, %w[owner_type owner_id relation],
+              unique: true,
+              name: "index_audiences_contexts_on_owner_type_owner_id_relation"
   end
 end

--- a/audiences/db/migrate/20240722025634_add_relation_to_context.rb
+++ b/audiences/db/migrate/20240722025634_add_relation_to_context.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddRelationToContext < ActiveRecord::Migration[6.1]
+  def change
+    add_column :audiences_contexts, :relation, :string, null: true
+    remove_index :audiences_contexts, %w[owner_type owner_id], unique: true
+    add_index :audiences_contexts, %w[owner_type owner_id relation], unique: true
+  end
+end

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Add `has_audience` and the ability to attach multiple audiences to the same owner [#363](https://github.com/powerhome/audiences/pull/363)
 - Audiences.config/configure helpers [#359](https://github.com/powerhome/audiences/pull/359)
 - Adjust user id to SCIM Protocol [#356](https://github.com/powerhome/audiences/pull/356)
 

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# Version 1.2.0 (2024-07-24)
+
 - Add `has_audience` and the ability to attach multiple audiences to the same owner [#363](https://github.com/powerhome/audiences/pull/363)
 - Audiences.config/configure helpers [#359](https://github.com/powerhome/audiences/pull/359)
 - Adjust user id to SCIM Protocol [#356](https://github.com/powerhome/audiences/pull/356)

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -10,13 +10,13 @@ Add this line to your application's Gemfile:
 gem "audiences"
 ```
 
-And then execute:
+Then execute:
 
 ```bash
-$ bundle
+$ bundle install
 ```
 
-Or install it yourself as:
+Or install it yourself with:
 
 ```bash
 $ gem install audiences
@@ -24,20 +24,18 @@ $ gem install audiences
 
 ## Usage
 
-### Creating/Managing audiences
+### Creating/Managing Audiences
 
-An audience is tied to an owning model withing your application. For the rest of this document we're going to assume a model Team. To create audiences for a team, using `audiences-react`, you'll render an audiences editor for your model.
+An audience is tied to an owning model within your application. In this document, we'll use a `Team` model as an example. To create audiences for a team using `audiences-react`, render an audiences editor for your model.
 
-That can be done with a unobstrusive JS renderer like react-rails, or a custom one as in [our dummy app](../audiences/spec/dummy/app/frontend/entrypoints/application.js). The editor will need two arguments:
+This can be done with an unobtrusive JS renderer like `react-rails` or a custom one as shown in [our dummy app](../audiences/spec/dummy/app/frontend/entrypoints/application.js). The editor requires two arguments:
 
 - The context URI: `audience_context_url(owner, relation)` helper
-- The SCIM endpoint: `audience_scim_proxy_url` helper if using the [proxy](#configuring-the-scim-proxy), or the SCIM endpoint.
+- The SCIM endpoint: `audience_scim_proxy_url` helper if using the [proxy](#configuring-the-scim-proxy), or the SCIM endpoint directly.
 
 ### Configuring Audiences
 
-The Audience::Scim should point to the SCIM endpoint. The service allows you to configure the endpoint and the credentials/headers:
-
-I.e.:
+The `Audience.config.scim` should point to the SCIM endpoint. Configure the endpoint and the credentials/headers as follows:
 
 ```ruby
 Audiences.configure do |config|
@@ -48,10 +46,9 @@ Audiences.configure do |config|
 end
 ```
 
-#### Adding audiences to a model
+### Adding Audiences to a Model
 
-A model object can contain multiple audience contexts. That is done using the `has_audience` module helper. This helper is added to ActiveRecord automatically when the configuration is set:
-
+A model object can contain multiple audience contexts using the `has_audience` module helper, which is added to ActiveRecord automatically when configured:
 
 ```ruby
 Audiences.configure do |config|
@@ -60,9 +57,9 @@ Audiences.configure do |config|
 end
 ```
 
-The `identity_class` is the class representing the SCIM user within the app domain. And the `identity_key` is the attrbiute in `identity_class` that maps directly to the SCIM User's externalId.
+The `identity_class` represents the SCIM user within the app domain, and the `identity_key` maps directly to the SCIM User's `externalId`.
 
-Once the above configuration is done, a model can add audience (see the [example owning model](../spec/dummy/app/models/example_owner.rb.rb)):
+Once configured, add audience contexts to a model:
 
 ```ruby
 class Survey < ApplicationRecord
@@ -71,9 +68,9 @@ class Survey < ApplicationRecord
 end
 ```
 
-#### Listening to audience changes
+### Listening to Audience Changes
 
-The goal of audiences is to allow the app to keep up with a mutable group of people. To allow that, `Audiences` allows the hosting app to subscribe to audiences related to a certain owner type, and react to that through a block:
+Audiences allow your app to keep up with mutable groups of people. To react to audience changes, subscribe to audiences related to a certain owner type and handle changes through a block:
 
 ```ruby
 Audiences.configure do |config|
@@ -85,7 +82,7 @@ Audiences.configure do |config|
 end
 ```
 
-or scheduling an AcitiveJob:
+Or schedule an ActiveJob:
 
 ```ruby
 Audiences.configure do |config|
@@ -96,29 +93,29 @@ Audiences.configure do |config|
 end
 ```
 
-Notice that the notifications block is executed every time the app is loaded or reloaded, through a `to_prepare` block. This allows autoloaded constants such as model and job classes to be referenced.
+The notifications block is executed every time the app is loaded or reloaded through a `to_prepare` block, allowing autoloaded constants such as model and job classes to be referenced.
 
-You can find a working example in our dummy app:
+See a working example in our dummy app:
 
-- [initializer](../spec/dummy/config/initializers/audiences.rb)
-- [job class](../spec/dummy/app/jobs/update_memberships_job.rb)
-- [example owning model](../spec/dummy/app/models/example_owner.rb.rb)
+- [Initializer](../spec/dummy/config/initializers/audiences.rb)
+- [Job class](../spec/dummy/app/jobs/update_memberships_job.rb)
+- [Example owning model](../spec/dummy/app/models/example_owner.rb)
 
-#### SCIM resource attributes
+### SCIM Resource Attributes
 
-You can configure which attributes are going to be requested to the SCIM backend for each resource type. Audiences requires that at least `id` and `displayName` are requested, and also requests `photos` for users by default. But you might want to request extra attributes to use them directly from `Audiences::ExternalUser`. This is possible using the `resource` configuration helper:
+Configure which attributes are requested from the SCIM backend for each resource type. `Audiences` requires at least `id` and `displayName`, and also requests `photos` and `externalId` for users by default. To request additional attributes:
 
 ```ruby
 Audiences.configure do |config|
-  config.resource :Users, attributes: "id,displayName,photos,name"
+  config.resource :Users, attributes: "id,externalId,displayName,photos,name"
   config.resource :Groups, attributes: "id,displayName,mfaRequired"
 end
 ```
 
 ## Contributing
 
-See [development guide](../../docs/development.md).
+For more information, see the [development guide](../../docs/development.md).
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+This gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -70,7 +70,7 @@ end
 
 ### Listening to Audience Changes
 
-Audiences allow your app to keep up with mutable groups of people. To react to audience changes, subscribe to audiences related to a certain owner type and handle changes through a block:
+Audiences allows your app to keep up with mutable groups of people. To react to audience changes, subscribe to audiences related to a certain owner type and handle changes through a block:
 
 ```ruby
 Audiences.configure do |config|

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -30,7 +30,7 @@ An audience is tied to an owning model withing your application. For the rest of
 
 That can be done with a unobstrusive JS renderer like react-rails, or a custom one as in [our dummy app](../audiences/spec/dummy/app/frontend/entrypoints/application.js). The editor will need two arguments:
 
-- The context URI: `audience_context_url(owner, relation:)` helper
+- The context URI: `audience_context_url(owner, relation)` helper
 - The SCIM endpoint: `audience_scim_proxy_url` helper if using the [proxy](#configuring-the-scim-proxy), or the SCIM endpoint.
 
 ### Configuring Audiences
@@ -45,6 +45,29 @@ Audiences.configure do |config|
     uri: ENV.fetch("SCIM_V2_API"),
     headers: { "Authorization" => "Bearer #{ENV.fetch('SCIM_V2_TOKEN')}" }
   }
+end
+```
+
+#### Adding audiences to a model
+
+A model object can contain multiple audience contexts. That is done using the `has_audience` module helper. This helper is added to ActiveRecord automatically when the configuration is set:
+
+
+```ruby
+Audiences.configure do |config|
+  config.identity_class = "User"
+  config.identity_key = "login"
+end
+```
+
+The `identity_class` is the class representing the SCIM user within the app domain. And the `identity_key` is the attrbiute in `identity_class` that maps directly to the SCIM User's externalId.
+
+Once the above configuration is done, a model can add audience (see the [example owning model](../spec/dummy/app/models/example_owner.rb.rb)):
+
+```ruby
+class Survey < ApplicationRecord
+  has_audience :responders
+  has_audience :supervisors
 end
 ```
 

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -30,7 +30,7 @@ An audience is tied to an owning model withing your application. For the rest of
 
 That can be done with a unobstrusive JS renderer like react-rails, or a custom one as in [our dummy app](../audiences/spec/dummy/app/frontend/entrypoints/application.js). The editor will need two arguments:
 
-- The context URI: `audience_context_url(owner)` helper
+- The context URI: `audience_context_url(owner, relation:)` helper
 - The SCIM endpoint: `audience_scim_proxy_url` helper if using the [proxy](#configuring-the-scim-proxy), or the SCIM endpoint.
 
 ### Configuring Audiences

--- a/audiences/gemfiles/rails_6_1.gemfile.lock
+++ b/audiences/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.1.2)
+    audiences (1.2.0)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_7_0.gemfile.lock
+++ b/audiences/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.1.2)
+    audiences (1.2.0)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_7_1.gemfile.lock
+++ b/audiences/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.1.2)
+    audiences (1.2.0)
       rails (>= 6.0)
 
 GEM

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -20,7 +20,7 @@ module_function
   # @return [String] context key
   #
   def sign(owner)
-    owner.to_sgid(for: GID_RESOURCE)
+    ::Audiences::Context.for(owner).to_sgid(for: GID_RESOURCE)
   end
 
   # Loads a context for the given context key
@@ -55,8 +55,8 @@ module_function
   end
 
   private_class_method def locate_context(key, &block)
-    owner = GlobalID::Locator.locate_signed(key, for: GID_RESOURCE)
-    ::Audiences::Context.for(owner).tap(&block)
+    GlobalID::Locator.locate_signed(key, for: GID_RESOURCE)
+                     .tap(&block)
   end
 end
 

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -19,8 +19,9 @@ module_function
   # @param owner [GlobalID::Identification] an owning model
   # @return [String] context key
   #
-  def sign(owner)
-    ::Audiences::Context.for(owner).to_sgid(for: GID_RESOURCE)
+  def sign(owner, relation: nil)
+    ::Audiences::Context.for(owner, relation: relation)
+                        .to_sgid(for: GID_RESOURCE)
   end
 
   # Loads a context for the given context key

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -5,33 +5,12 @@
 # SCIM backend updates a user, notifying matching audiences.
 #
 module Audiences
+  autoload :Model, "audiences/model"
   autoload :Notifications, "audiences/notifications"
   autoload :Scim, "audiences/scim"
   autoload :VERSION, "audiences/version"
 
-  GID_RESOURCE = "audiences"
-
 module_function
-
-  # Provides a key to load an audience context for the given owner.
-  # An owner should implment GlobalID::Identification.
-  #
-  # @param owner [GlobalID::Identification] an owning model
-  # @return [String] context key
-  #
-  def sign(owner, relation: nil)
-    ::Audiences::Context.for(owner, relation: relation)
-                        .to_sgid(for: GID_RESOURCE)
-  end
-
-  # Loads a context for the given context key
-  #
-  # @param token [String] a signed token (see #sign)
-  # @return Audience::Context
-  #
-  def load(key)
-    locate_context(key, &:readonly!)
-  end
 
   # Updates the given context
   #
@@ -45,19 +24,13 @@ module_function
   # @return Audience::Context
   #
   def update(key, criteria: [], **attrs)
-    locate_context(key) do |context|
+    Audiences::Context.load(key) do |context|
       context.update!(
         criteria: ::Audiences::Criterion.map(criteria),
         **attrs
       )
       context.refresh_users!
-      context.readonly!
     end
-  end
-
-  private_class_method def locate_context(key, &block)
-    GlobalID::Locator.locate_signed(key, for: GID_RESOURCE)
-                     .tap(&block)
   end
 end
 

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -6,6 +6,17 @@ module Audiences
   # Configuration options
 
   #
+  # Identity model representing a SCIM User in the current application. I.e.: "User"
+  #
+  config_accessor :identity_class
+
+  #
+  # The key attribute on `identity_class` matching with the SCIM User externalId.
+  # This configuration defaults to `:id`
+  #
+  config_accessor(:identity_key) { :id }
+
+  #
   # SCIM service configurations. This should be a Hash containint, at least, the URI.
   #
   # I.e.:

--- a/audiences/lib/audiences/engine.rb
+++ b/audiences/lib/audiences/engine.rb
@@ -9,5 +9,13 @@ module Audiences
   #
   class Engine < ::Rails::Engine
     isolate_namespace Audiences
+
+    initializer "audiences.model" do
+      if Audiences.config.identity_class
+        ActiveSupport.on_load(:active_record) do
+          include Audiences::Model
+        end
+      end
+    end
   end
 end

--- a/audiences/lib/audiences/model.rb
+++ b/audiences/lib/audiences/model.rb
@@ -10,7 +10,8 @@ module Audiences
       #
       # @param name [Symbol,String] the member relationship name
       #
-      def has_audience(name) # rubocop:disable Naming/PredicateName
+      # rubocop:disable Naming/PredicateName,Metrics/MethodLength,Metrics/AbcSize
+      def has_audience(name)
         has_one :"#{name}_context", -> { where(relation: name) },
                 as: :owner, dependent: :destroy,
                 class_name: "Audiences::Context"
@@ -19,10 +20,15 @@ module Audiences
                  class_name: "Audiences::ExternalUser"
         has_many name, -> { readonly }, through: :"#{name}_external_users", source: :identity
 
+        scope :"with_#{name}", -> { includes(name) }
+        scope :"with_#{name}_context", -> { includes(:"#{name}_context") }
+        scope :"with_#{name}_external_users", -> { includes(:"#{name}_external_users") }
+
         after_initialize if: :new_record? do
           association(:"#{name}_context").build
         end
       end
+      # rubocop:enable Naming/PredicateName,Metrics/MethodLength,Metrics/AbcSize
     end
   end
 end

--- a/audiences/lib/audiences/model.rb
+++ b/audiences/lib/audiences/model.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Audiences
+  module Model
+    extend ActiveSupport::Concern
+
+    class_methods do
+      #
+      # Adds relationships between the audience context and the owner object
+      #
+      # @param name [Symbol,String] the member relationship name
+      #
+      def has_audience(name) # rubocop:disable Naming/PredicateName
+        has_one :"#{name}_context", -> { where(relation: name) },
+                as: :owner, dependent: :destroy,
+                class_name: "Audiences::Context"
+        has_many :"#{name}_external_users",
+                 through: :"#{name}_context", source: :users,
+                 class_name: "Audiences::ExternalUser"
+        has_many name, -> { readonly }, through: :"#{name}_external_users", source: :identity
+      end
+    end
+  end
+end

--- a/audiences/lib/audiences/model.rb
+++ b/audiences/lib/audiences/model.rb
@@ -18,6 +18,10 @@ module Audiences
                  through: :"#{name}_context", source: :users,
                  class_name: "Audiences::ExternalUser"
         has_many name, -> { readonly }, through: :"#{name}_external_users", source: :identity
+
+        after_initialize if: :new_record? do
+          association(:"#{name}_context").build
+        end
       end
     end
   end

--- a/audiences/lib/audiences/version.rb
+++ b/audiences/lib/audiences/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Audiences
-  VERSION = "1.1.2"
+  VERSION = "1.2.0"
 end

--- a/audiences/spec/dummy/app/models/example_owner.rb
+++ b/audiences/spec/dummy/app/models/example_owner.rb
@@ -4,4 +4,5 @@ class ExampleOwner < ApplicationRecord
   has_many :memberships, class_name: "ExampleMembership",
                          foreign_key: :owner_id,
                          dependent: :delete_all
+  has_audience :members
 end

--- a/audiences/spec/dummy/app/models/example_user.rb
+++ b/audiences/spec/dummy/app/models/example_user.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ExampleUser < ApplicationRecord
+end

--- a/audiences/spec/dummy/app/views/example_owners/_example_owner.html.erb
+++ b/audiences/spec/dummy/app/views/example_owners/_example_owner.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= dom_id example_owner %>">
   <p>
     <strong>Name:</strong>
-    <%= example_owner.name %> (<%= example_owner.memberships.count %> memberships)
+    <%= example_owner.name %> (<%= example_owner.members.count %> memberships)
   </p>
 
 </div>

--- a/audiences/spec/dummy/app/views/example_owners/show.html.erb
+++ b/audiences/spec/dummy/app/views/example_owners/show.html.erb
@@ -8,4 +8,4 @@
 
 <%= render @example_owner %>
 
-<%= tag(:div, data: { context: audience_context_path(@example_owner), scim: audience_scim_proxy_path }) %>
+<%= tag(:div, data: { context: audience_context_path(@example_owner, :members), scim: audience_scim_proxy_path }) %>

--- a/audiences/spec/dummy/config/initializers/audiences.rb
+++ b/audiences/spec/dummy/config/initializers/audiences.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Audiences.configure do |config|
+  config.identity_class = "ExampleUser"
+
   config.scim = {
     uri: ENV.fetch("SCIM_V2_API", "http://example.com/scim/v2/"),
     headers: { "Authorization" => ENV.fetch("SCIM_AUTHORIZATION", "Bearer 123456789") },

--- a/audiences/spec/dummy/config/routes.rb
+++ b/audiences/spec/dummy/config/routes.rb
@@ -2,5 +2,6 @@
 
 Rails.application.routes.draw do
   resources :example_owners
+  mount Audiences::Engine, at: "/audiences"
   root to: "example_owners#index"
 end

--- a/audiences/spec/dummy/db/migrate/20240719103455_create_audiences_users.rb
+++ b/audiences/spec/dummy/db/migrate/20240719103455_create_audiences_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateAudiencesUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :example_users do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,16 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_05_140046) do
+ActiveRecord::Schema.define(version: 2024_07_22_025634) do
 
   create_table "audiences_contexts", force: :cascade do |t|
     t.string "owner_type", null: false
     t.integer "owner_id", null: false
     t.boolean "match_all", default: false, null: false
-    t.datetime "created_at", precision: 0, null: false
-    t.datetime "updated_at", precision: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.json "extra_users"
-    t.index ["owner_type", "owner_id"], name: "index_audiences_contexts_on_owner_type_and_owner_id", unique: true
+    t.string "relation"
+    t.index ["owner_type", "owner_id", "relation"], name: "index_audiences_contexts_on_owner_type_and_owner_id_and_relation", unique: true
   end
 
   create_table "audiences_criterions", force: :cascade do |t|

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -20,8 +20,7 @@ ActiveRecord::Schema.define(version: 2024_07_22_025634) do
     t.datetime "updated_at", null: false
     t.json "extra_users"
     t.string "relation"
-    t.index ["owner_type", "owner_id", "relation"],
-            name: "index_audiences_contexts_on_owner_type_and_owner_id_and_relation", unique: true
+    t.index ["owner_type", "owner_id", "relation"], name: "index_audiences_contexts_on_owner_type_owner_id_relation", unique: true
   end
 
   create_table "audiences_criterions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2024_07_22_025634) do
 
-  create_table "audiences_contexts", force: :cascade do |t|
+  create_table "audiences_contexts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "owner_type", null: false
     t.integer "owner_id", null: false
     t.boolean "match_all", default: false, null: false
@@ -20,50 +20,57 @@ ActiveRecord::Schema.define(version: 2024_07_22_025634) do
     t.datetime "updated_at", null: false
     t.json "extra_users"
     t.string "relation"
-    t.index ["owner_type", "owner_id", "relation"], name: "index_audiences_contexts_on_owner_type_and_owner_id_and_relation", unique: true
+    t.index ["owner_type", "owner_id", "relation"],
+            name: "index_audiences_contexts_on_owner_type_and_owner_id_and_relation", unique: true
   end
 
-  create_table "audiences_criterions", force: :cascade do |t|
+  create_table "audiences_criterions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.json "groups"
     t.integer "context_id", null: false
-    t.datetime "created_at", precision: 0, null: false
-    t.datetime "updated_at", precision: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.datetime "refreshed_at"
     t.index ["context_id"], name: "index_audiences_criterions_on_context_id"
   end
 
-  create_table "audiences_external_users", force: :cascade do |t|
+  create_table "audiences_external_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "user_id", null: false
     t.json "data"
-    t.datetime "created_at", precision: 0, null: false
-    t.datetime "updated_at", precision: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_audiences_external_users_on_user_id", unique: true
   end
 
-  create_table "audiences_memberships", force: :cascade do |t|
+  create_table "audiences_memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "external_user_id", null: false
     t.string "group_type", null: false
     t.integer "group_id", null: false
-    t.datetime "created_at", precision: 0, null: false
-    t.datetime "updated_at", precision: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["external_user_id"], name: "index_audiences_memberships_on_external_user_id"
     t.index ["group_type", "group_id"], name: "index_audiences_memberships_on_group_type_and_group_id"
   end
 
-  create_table "example_memberships", force: :cascade do |t|
+  create_table "example_memberships", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "owner_id"
     t.integer "user_id"
     t.string "name"
     t.string "photo"
-    t.datetime "created_at", precision: 0, null: false
-    t.datetime "updated_at", precision: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["owner_id"], name: "index_example_memberships_on_owner_id"
   end
 
-  create_table "example_owners", force: :cascade do |t|
+  create_table "example_owners", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
-    t.datetime "created_at", precision: 0, null: false
-    t.datetime "updated_at", precision: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "example_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
 end

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -3,20 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Audiences do
-  describe ".sign" do
-    it "creates a signed token to a given context" do
-      cricket_club = ExampleOwner.create(name: "Cricket Club")
-
-      token = Audiences.sign(cricket_club)
-      context = Audiences.load(token)
-
-      expect(context.owner).to eql cricket_club
-    end
-  end
-
   describe ".update" do
     let(:baseball_club) { ExampleOwner.create(name: "Baseball Club") }
-    let(:token) { Audiences.sign(baseball_club) }
+    let(:token) { Audiences::Context.for(baseball_club).signed_key }
 
     it "updates an audience context from a given key and params" do
       stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")

--- a/audiences/spec/models/audiences/context/locating_spec.rb
+++ b/audiences/spec/models/audiences/context/locating_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Audiences::Context::Locating do
+  let(:owner) { ExampleOwner.create(name: "Example") }
+
+  describe ".sign" do
+    it "creates a signed token to a given context" do
+      cricket_club = ExampleOwner.create(name: "Cricket Club")
+      context = Audiences::Context.for(cricket_club)
+
+      loaded_context = Audiences::Context.load(context.signed_key)
+
+      expect(loaded_context.owner).to eql cricket_club
+    end
+  end
+
+  describe ".for(owner)" do
+    it "fetches an existing context" do
+      expect(Audiences::Context.for(owner, relation: :members)).to eql owner.members_context
+    end
+
+    it "creates a new context when one doesn't exist" do
+      expect(Audiences::Context.for(owner)).to be_a Audiences::Context
+      expect(Audiences::Context.for(owner)).to be_persisted
+    end
+  end
+end

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -3,36 +3,35 @@
 require "rails_helper"
 
 RSpec.describe Audiences::Context do
-  let(:owner) { ExampleOwner.create(name: "Example") }
+  let(:owner) { ExampleOwner.new(name: "Example") }
 
   describe "#refresh_users!" do
     it "publishes a notification about the context update" do
-      context = Audiences::Context.for(owner)
-
       expect do |blk|
         Audiences::Notifications.subscribe ExampleOwner, &blk
-        context.refresh_users!
-      end.to yield_with_args
+        owner.save!
+        owner.members_context.refresh_users!
+      end.to yield_with_args(owner.members_context)
     end
   end
 
   describe "#match_all" do
     it "clears other criteria when set to match all" do
-      context = Audiences::Context.for(owner)
-      context.criteria.create(groups: { Departments: [1, 3, 4] })
+      owner.members_context.criteria.build(groups: { Departments: [1, 3, 4] })
+      owner.members_context.match_all = true
 
-      context.update(match_all: true)
+      owner.save!
 
-      expect(context.criteria).to be_empty
+      expect(owner.members_context.criteria).to be_empty
     end
 
     it "clears extra users when set to match all" do
-      context = Audiences::Context.for(owner)
-      context.update(extra_users: [{ "id" => 123 }])
+      owner.members_context.extra_users = [{ "id" => 123 }]
+      owner.members_context.match_all = true
 
-      context.update(match_all: true)
+      owner.save!
 
-      expect(context.extra_users).to be_empty
+      expect(owner.members_context.extra_users).to be_empty
     end
   end
 
@@ -40,30 +39,16 @@ RSpec.describe Audiences::Context do
     it { is_expected.to belong_to(:owner) }
   end
 
-  describe ".for(owner)" do
-    it "fetches an existing context" do
-      context = Audiences::Context.create(owner: owner)
-
-      expect(Audiences::Context.for(owner)).to eql context
-    end
-
-    it "creates a new context when one doesn't exist" do
-      expect(Audiences::Context.for(owner)).to be_a Audiences::Context
-    end
-  end
-
   describe "#count" do
     it "is the total of all member users" do
-      user1 = external_user(id: 1)
-      user2 = external_user(id: 2)
+      owner.save!
 
-      context = Audiences::Context.create!(owner: owner, users: [user1, user2])
+      owner.members_context.users.create([
+                                           { user_id: 1 },
+                                           { user_id: 2 },
+                                         ])
 
-      expect(context.count).to eql 2
+      expect(owner.members_context.count).to eql 2
     end
-  end
-
-  def external_user(**data)
-    Audiences::ExternalUser.new(user_id: data[:id], data: data)
   end
 end

--- a/audiences/spec/models/audiences/model_spec.rb
+++ b/audiences/spec/models/audiences/model_spec.rb
@@ -19,4 +19,14 @@ RSpec.describe Audiences::Model do
                                         .source(:identity)
     end
   end
+
+  it "builds the audience context as the owner is built" do
+    expect(subject.members_context).to be_present
+  end
+
+  it "saves the audience context as the owner is saved" do
+    subject.save!
+
+    expect(subject.members_context).to be_persisted
+  end
 end

--- a/audiences/spec/models/audiences/model_spec.rb
+++ b/audiences/spec/models/audiences/model_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Audiences::Model do
+  subject { ExampleOwner.new }
+
+  describe "dynamic owner to audience relations" do
+    it do
+      is_expected.to have_one(:members_context).class_name("Audiences::Context")
+    end
+    it do
+      is_expected.to have_many(:members_external_users).class_name("Audiences::ExternalUser")
+                                                       .through(:members_context)
+                                                       .source(:users)
+    end
+    it do
+      is_expected.to have_many(:members).through(:members_external_users)
+                                        .source(:identity)
+    end
+  end
+end

--- a/audiences/spec/models/audiences/model_spec.rb
+++ b/audiences/spec/models/audiences/model_spec.rb
@@ -20,6 +20,28 @@ RSpec.describe Audiences::Model do
     end
   end
 
+  describe "dynamic scopes" do
+    before { subject.save! }
+
+    it "allows to eager load the members" do
+      owner = ExampleOwner.with_members.first
+
+      expect(owner.association(:members)).to be_loaded
+    end
+
+    it "allows to eager load the contexts" do
+      owner = ExampleOwner.with_members_context.first
+
+      expect(owner.association(:members_context)).to be_loaded
+    end
+
+    it "allows to eager load the external users" do
+      owner = ExampleOwner.with_members_external_users.first
+
+      expect(owner.association(:members_external_users)).to be_loaded
+    end
+  end
+
   it "builds the audience context as the owner is built" do
     expect(subject.members_context).to be_present
   end

--- a/audiences/spec/requests/contexts_api_spec.rb
+++ b/audiences/spec/requests/contexts_api_spec.rb
@@ -4,11 +4,10 @@ require "rails_helper"
 
 RSpec.describe "/audiences" do
   let(:example_owner) { ExampleOwner.create!(name: "Example Owner") }
-  let(:context_key) { Audiences::Context.for(example_owner).signed_key }
 
   describe "GET /audiences/:context_key" do
     it "responds with the audience context json" do
-      get audiences.signed_context_path(context_key)
+      get audience_context_path(example_owner, :members)
 
       expect(response.parsed_body).to match({
                                               "match_all" => false,
@@ -30,21 +29,22 @@ RSpec.describe "/audiences" do
       stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
         .to_return(status: 200, body: users_response.to_json, headers: {})
 
-      put audiences.signed_context_path(context_key), as: :json, params: { match_all: true }
+      put audience_context_path(example_owner, :members), as: :json, params: { match_all: true }
 
-      context = Audiences::Context.for(example_owner)
+      context = example_owner.members_context.reload
 
       expect(context).to be_match_all
       expect(context.users.count).to eql 2
     end
 
     it "updates the context extra users" do
-      put audiences.signed_context_path(context_key),
+      put audience_context_path(example_owner, :members),
           as: :json,
           params: { extra_users: [{ externalId: 123, displayName: "John Doe",
                                     photos: [{ value: "http://example.com" }] }] }
 
-      context = Audiences::Context.for(example_owner)
+      context = example_owner.members_context.reload
+
       expect(context.extra_users).to eql [{
         "externalId" => 123,
         "displayName" => "John Doe",
@@ -53,7 +53,7 @@ RSpec.describe "/audiences" do
     end
 
     it "responds with the audience context json" do
-      put audiences.signed_context_path(context_key),
+      put audience_context_path(example_owner, :members),
           as: :json,
           params: { extra_users: [{ externalId: 123, displayName: "John Doe",
                                     photos: [{ value: "http://example.com" }] }] }
@@ -91,7 +91,7 @@ RSpec.describe "/audiences" do
                            "&filter=groups.value eq 987")
           .to_return(status: 200, body: users_response.to_json, headers: {})
 
-        put audiences.signed_context_path(context_key),
+        put audience_context_path(example_owner, :members),
             as: :json,
             params: {
               match_all: false,
@@ -133,12 +133,13 @@ RSpec.describe "/audiences" do
 
   describe "GET /audiences/:context_key/users" do
     it "is the list of users from an audience context" do
-      context = Audiences::Context.for(example_owner)
-      context.users.create(user_id: 123, data: { "externalId" => 123 })
-      context.users.create(user_id: 456, data: { "externalId" => 456 })
-      context.users.create(user_id: 789, data: { "externalId" => 789 })
+      example_owner.members_context.users.create([
+                                                   { user_id: 123, data: { "externalId" => 123 } },
+                                                   { user_id: 456, data: { "externalId" => 456 } },
+                                                   { user_id: 789, data: { "externalId" => 789 } },
+                                                 ])
 
-      get audiences.users_path(context_key)
+      get audiences.users_path(example_owner.members_context.signed_key)
 
       expect(response.parsed_body).to match({
                                               "count" => 3,
@@ -153,13 +154,20 @@ RSpec.describe "/audiences" do
 
   describe "GET /audiences/:context_key/users/:criterion_id" do
     it "is the list of users from an audience context's criterion" do
-      context = Audiences::Context.for(example_owner)
-      criterion = context.criteria.create!
-      criterion.users.create(user_id: 1, data: { "externalId" => 1, "displayName" => "John" })
-      criterion.users.create(user_id: 2, data: { "externalId" => 2, "displayName" => "Jose" })
-      criterion.users.create(user_id: 3, data: { "externalId" => 3, "displayName" => "Nelson" })
+      criterion = example_owner.members_context.criteria.create!
+      criterion.users.create!([
+                                { user_id: 1,
+                                  data: { "externalId" => 1,
+                                          "displayName" => "John" } },
+                                { user_id: 2,
+                                  data: { "externalId" => 2,
+                                          "displayName" => "Jose" } },
+                                { user_id: 3,
+                                  data: { "externalId" => 3,
+                                          "displayName" => "Nelson" } },
+                              ])
 
-      get audiences.users_path(context_key, criterion_id: criterion.id)
+      get audiences.users_path(example_owner.members_context.signed_key, criterion_id: criterion.id)
 
       expect(response.parsed_body).to match_array({
                                                     "count" => 3,

--- a/audiences/spec/requests/contexts_api_spec.rb
+++ b/audiences/spec/requests/contexts_api_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "/audiences" do
   let(:example_owner) { ExampleOwner.create!(name: "Example Owner") }
-  let(:context_key) { Audiences.sign(example_owner) }
+  let(:context_key) { Audiences::Context.for(example_owner).signed_key }
 
   describe "GET /audiences/:context_key" do
     it "responds with the audience context json" do
@@ -91,7 +91,7 @@ RSpec.describe "/audiences" do
                            "&filter=groups.value eq 987")
           .to_return(status: 200, body: users_response.to_json, headers: {})
 
-        put audience_context_path(example_owner),
+        put audiences.signed_context_path(context_key),
             as: :json,
             params: {
               match_all: false,


### PR DESCRIPTION
This Pull Request enhances the "Audiences" gem by enabling models to connect to multiple audiences (such as members, admins, managers, etc.) using the new `has_audience` helper. 

### Key Features:

- **Multiple Audience Connections**: Models can now be associated with multiple audience contexts.
- **New Helper Method**: The `has_audience` helper facilitates the creation and management of these audience connections.

### Configuration Additions:

This PR introduces the following configuration options:

```ruby
#
# Identity model representing a SCIM User in the current application. Example: "User"
#
config_accessor :identity_class

#
# The key attribute on `identity_class` that matches with the SCIM User's externalId.
# This configuration defaults to `:id`
#
config_accessor(:identity_key) { :id }
```

### Additional Improvements:

- **Direct Context Linking**: Audiences are now linked to the backend directly through the context.
- **API Simplification**: The public Audiences API has been reduced in favor of a private model API.
- **Auto-initialized Contexts**: Audience contexts are automatically initialized when the owner is created or built.

These changes streamline the integration and management of SCIM audiences within your Rails application, improving overall functionality and ease of use.