### PR TITLE
Permit configured resource attributes

### DIFF
--- a/audiences/Gemfile.lock
+++ b/audiences/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    audiences (1.2.1)
+    audiences (1.2.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -44,7 +44,7 @@ module Audiences
       params.permit(
         :match_all,
         criteria: [groups: {}],
-        extra_users: [:externalId, :displayName, { photos: %i[type value] }]
+        extra_users: Audiences.config.resources[:Users].attributes
       ).to_h.symbolize_keys
     end
   end

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 1.2.2 (2024-08-21)
+
+- Permit configured resource attributes [#375](https://github.com/powerhome/audiences/pull/375)
+
 # Version 1.2.1 (2024-08-06)
 
 - Fix audiences URL helpers [#372](https://github.com/powerhome/audiences/pull/372)

--- a/audiences/docs/README.md
+++ b/audiences/docs/README.md
@@ -103,12 +103,12 @@ See a working example in our dummy app:
 
 ### SCIM Resource Attributes
 
-Configure which attributes are requested from the SCIM backend for each resource type. `Audiences` requires at least `id` and `displayName`, and also requests `photos` and `externalId` for users by default. To request additional attributes:
+Configure which attributes are requested from the SCIM backend for each resource type. `Audiences` includes `id`, `externalId`, and `displayName` by default in every resource type. It also requests `photos.type` and `photos.value` for users by default. To request additional attributes:
 
 ```ruby
 Audiences.configure do |config|
-  config.resource :Users, attributes: "id,externalId,displayName,photos,name"
-  config.resource :Groups, attributes: "id,displayName,mfaRequired"
+  config.resource :Users, attributes: ["name" => %w[givenName familyName formatted]]
+  config.resource :Groups, attributes: %w[mfaRequired]
 end
 ```
 

--- a/audiences/gemfiles/rails_6_1.gemfile.lock
+++ b/audiences/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.2.1)
+    audiences (1.2.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_7_0.gemfile.lock
+++ b/audiences/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.2.1)
+    audiences (1.2.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_7_1.gemfile.lock
+++ b/audiences/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.2.1)
+    audiences (1.2.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -46,7 +46,7 @@ module Audiences
   # @see `resource`.
   #
   config_accessor :resources do
-    { Users: Scim::Resource.new(type: :Users, attributes: "id,externalId,displayName,photos") }
+    { Users: Scim::Resource.new(type: :Users, attributes: ["id", "externalId", "displayName", "photos" => %w[type value]]) }
   end
 
   #

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -55,8 +55,8 @@ module Audiences
   # @param type [Symbol] the resource type in plural, as in scim (i.e.: :Users)
   # @param attributes [String] the list of attributes to fetch for the resource (i.e.: "id,externalId,displayName")
   # @see [Audiences::Scim::Resource]
-  def config.resource(type:, **kwargs)
-    config.resources[type] = Scim::Resource.new(type: type, **kwargs)
+  def config.resource(type, **kwargs)
+    resources[type] = Scim::Resource.new(type: type, **kwargs)
   end
 
   #

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -46,7 +46,7 @@ module Audiences
   # @see `resource`.
   #
   config_accessor :resources do
-    { Users: Scim::Resource.new(type: :Users, attributes: ["id", "externalId", "displayName", "photos" => %w[type value]]) }
+    { Users: Scim::Resource.new(type: :Users, attributes: ["photos" => %w[type value]]) }
   end
 
   #

--- a/audiences/lib/audiences/scim/resource.rb
+++ b/audiences/lib/audiences/scim/resource.rb
@@ -13,8 +13,21 @@ module Audiences
 
       def query(**options)
         ResourcesQuery.new(Scim.client, resource: self,
-                                        attributes: @attributes.join(","),
+                                        attributes: scim_attributes,
                                         **@options, **options)
+      end
+
+      def scim_attributes
+        @attributes.reduce([]) do |attrs, attr|
+          case attr
+          when Hash
+            attrs + attr.map do |key, nested_attrs|
+              nested_attrs.map { "#{key}.#{_1}" }
+            end
+          else
+            attrs + [attr]
+          end
+        end.join(",")
       end
     end
   end

--- a/audiences/lib/audiences/scim/resource.rb
+++ b/audiences/lib/audiences/scim/resource.rb
@@ -5,10 +5,10 @@ module Audiences
     class Resource
       attr_accessor :options, :type, :attributes
 
-      def initialize(type:, attributes: %w[id externalId displayName], **options)
+      def initialize(type:, attributes: [], **options)
         @type = type
         @options = options
-        @attributes = attributes
+        @attributes = ["id", "externalId", "displayName", *attributes]
       end
 
       def query(**options)

--- a/audiences/lib/audiences/scim/resource.rb
+++ b/audiences/lib/audiences/scim/resource.rb
@@ -3,16 +3,18 @@
 module Audiences
   module Scim
     class Resource
-      attr_accessor :options, :type
+      attr_accessor :options, :type, :attributes
 
-      def initialize(type:, attributes: "id,externalId,displayName", **options)
+      def initialize(type:, attributes: %w[id externalId displayName], **options)
         @type = type
         @options = options
-        @options[:attributes] = attributes
+        @attributes = attributes
       end
 
       def query(**options)
-        ResourcesQuery.new(Scim.client, resource: self, **@options, **options)
+        ResourcesQuery.new(Scim.client, resource: self,
+                                        attributes: @attributes.join(","),
+                                        **@options, **options)
       end
     end
   end

--- a/audiences/lib/audiences/version.rb
+++ b/audiences/lib/audiences/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Audiences
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/audiences/spec/lib/audiences/scim_spec.rb
+++ b/audiences/spec/lib/audiences/scim_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 RSpec.describe Audiences::Scim do
   describe ".resources" do
     it "fetches the resource definition by the type key" do
-      Audiences.config.resources[:Test] = Audiences::Scim::Resource.new(type: :Test, attributes: "id,photos")
+      Audiences.config.resources[:Test] = Audiences::Scim::Resource.new(type: :Test, attributes: %w[photos])
 
       resource = Audiences::Scim.resource(:Test)
 
       expect(resource.type).to be :Test
-      expect(resource.options).to match({ attributes: "id,photos" })
+      expect(resource.attributes).to match_array %w[id externalId displayName photos]
     end
 
     it "creates a new resource definition when one doesn't exist" do

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Audiences do
     let(:token) { Audiences::Context.for(baseball_club).signed_key }
 
     it "updates an audience context from a given key and params" do
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos.type,photos.value")
         .with(query: {})
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
 
@@ -26,16 +26,16 @@ RSpec.describe Audiences do
     end
 
     it "updates group criterion" do
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos.type,photos.value")
         .with(query: { filter: "groups.value eq 1 OR groups.value eq 2" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos.type,photos.value")
         .with(query: { filter: "groups.value eq 3 OR groups.value eq 4" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos.type,photos.value")
         .with(query: { filter: "groups.value eq 5 OR groups.value eq 6" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos.type,photos.value")
         .with(query: { filter: "groups.value eq 7 OR groups.value eq 8" })
         .to_return(status: 200, body: { "Resources" => [] }.to_json)
 

--- a/audiences/spec/models/audiences/context_users_spec.rb
+++ b/audiences/spec/models/audiences/context_users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Audiences::ContextUsers do
           { "externalId" => 1414 },
         ],
       }
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos.type,photos.value")
         .to_return(status: 200, body: response.to_json)
 
       context = Audiences::Context.new(match_all: true)

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Audiences::Criterion do
     let(:context) { Audiences::Context.for(owner) }
 
     it "fetches the criteria matching users" do
-      attrs = "id,externalId,displayName,photos"
+      attrs = "id,externalId,displayName,photos.type,photos.value"
       stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}&filter=groups.value eq 123")
         .to_return(status: 200, body: { "Resources" => [{ "externalId" => 13 }] }.to_json)
 

--- a/audiences/spec/models/audiences/criterion_users_spec.rb
+++ b/audiences/spec/models/audiences/criterion_users_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Audiences::CriterionUsers do
       ],
     }
 
-    stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+    attrs = "id,externalId,displayName,photos.type,photos.value"
+    stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                        "&filter=groups.value eq 1 OR groups.value eq 3")
       .to_return(status: 200, body: response.to_json)
 
@@ -44,10 +45,11 @@ RSpec.describe Audiences::CriterionUsers do
         ],
       }
 
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+      attrs = "id,externalId,displayName,photos.type,photos.value"
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                          "&filter=groups.value eq 1 OR groups.value eq 3")
         .to_return(status: 200, body: response1or3.to_json)
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                          "&filter=groups.value eq 5 OR groups.value eq 6")
         .to_return(status: 200, body: response5or6.to_json)
 
@@ -78,11 +80,12 @@ RSpec.describe Audiences::CriterionUsers do
         ],
       }
 
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+      attrs = "id,externalId,displayName,photos.type,photos.value"
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                          "&filter=groups.value eq 1 OR groups.value eq 3")
         .to_return(status: 200, body: response1or3.to_json)
 
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos&filter=")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}&filter=")
         .to_return(status: 200, body: response_no_filter.to_json)
 
       users = Audiences::CriterionUsers.new(criterion).to_a

--- a/audiences/spec/requests/contexts_api_spec.rb
+++ b/audiences/spec/requests/contexts_api_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "/audiences" do
     end
 
     it "updates the audience context to match all" do
-      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos")
+      stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos.type,photos.value")
         .to_return(status: 200, body: users_response.to_json, headers: {})
 
       put audience_context_path(example_owner, :members), as: :json, params: { match_all: true }
@@ -78,16 +78,17 @@ RSpec.describe "/audiences" do
       end
 
       it "allows updating the group criteria" do
-        stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+        attrs = "id,externalId,displayName,photos.type,photos.value"
+        stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                            "&filter=groups.value eq 123")
           .to_return(status: 200, body: users_response.to_json, headers: {})
-        stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+        stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                            "&filter=groups.value eq 321")
           .to_return(status: 200, body: users_response.to_json, headers: {})
-        stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+        stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                            "&filter=groups.value eq 789")
           .to_return(status: 200, body: users_response.to_json, headers: {})
-        stub_request(:get, "http://example.com/scim/v2/Users?attributes=id,externalId,displayName,photos" \
+        stub_request(:get, "http://example.com/scim/v2/Users?attributes=#{attrs}" \
                            "&filter=groups.value eq 987")
           .to_return(status: 200, body: users_response.to_json, headers: {})
 


### PR DESCRIPTION
While we're allowed to configure the attributes returned from SCIM, the `ContextsController` would not allow that configuration and hard-coded the allowed attributes for a user. This is the root cause for #374.

This PR allows the configured attributes to be sent back to the ContextsController, while retaining most of the API.

### Breaking changes

> [!WARNING]
> Applications with attributes configured should update their configuration to an array of attributes, instead of a SCIM string representation of that attribute list.

### Changes

- **Fix resource configuration**
- **Remove options from resource fetching**
- **Strip schemas and meta from SCIM proxy**
- **Allow user requested attributes to update context**
- **Make id, externalId, and displayName non-optional for all resources**
- **Support shallow attribute nesting when requesting SCIM resource attributes**
- **Update documentation to array attributes**

Fixes #374