### PR TITLE
[JEDI-382] Forward pagination parameters to SCIM

### DIFF
--- a/audiences/app/controllers/audiences/scim_proxy_controller.rb
+++ b/audiences/app/controllers/audiences/scim_proxy_controller.rb
@@ -4,7 +4,7 @@ module Audiences
   class ScimProxyController < ApplicationController
     def get
       resources = Audiences::Scim.resource(params[:scim_path].to_sym)
-                                 .query(filter: params[:filter])
+                                 .query(filter: params[:filter], startIndex: params[:startIndex], count: params[:count])
 
       render json: resources, except: %w[schemas meta]
     end


### PR DESCRIPTION
https://runway.powerhrg.com/backlog_items/JEDI-382

Before, both
```
curl -X GET 'http://localhost:3000/audiences/scim/Titles?count=1' | json_pp
```
and
```
curl -X GET 'http://localhost:3000/audiences/scim/Titles?startIndex=101' | json_pp
```
returned the same response as a simple `GET /audiences/scim/Titles`. The `count` and `startIndex` parameters are valid for paginating SCIM and work when querying `https://id.powerhrg.com/api/scim` directly. This change forwards both parameters (if present) so that the SCIM request includes them.