### PR TITLE
Filter sensitive user data out of user list response

### DIFF
--- a/audiences/Gemfile.lock
+++ b/audiences/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    audiences (1.5.1)
+    audiences (1.5.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -17,7 +17,7 @@ module Audiences
                                limit: params[:limit],
                                offset: params[:offset])
 
-      render json: search
+      render json: search, only: %w[id externalId displayName photos]
     end
 
   private

--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -36,7 +36,7 @@ module Audiences
       json_setting = {
         only: %i[match_all],
         methods: %i[count],
-        include: { criteria: { only: %i[id groups], methods: %i[count] } }
+        include: { criteria: { only: %i[id groups], methods: %i[count] } },
       }
       extra_users = context.extra_users.as_json(only: Audiences.exposed_user_attributes)
 

--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -17,7 +17,7 @@ module Audiences
                                limit: params[:limit],
                                offset: params[:offset])
 
-      render json: search, only: %w[id externalId displayName photos]
+      render json: search, only: Audiences.exposed_user_attributes
     end
 
   private
@@ -33,11 +33,14 @@ module Audiences
     end
 
     def render_context(context)
-      render json: context.as_json(
-        only: %i[match_all extra_users],
+      json_setting = {
+        only: %i[match_all],
         methods: %i[count],
         include: { criteria: { only: %i[id groups], methods: %i[count] } }
-      )
+      }
+      extra_users = context.extra_users.as_json(only: Audiences.exposed_user_attributes)
+
+      render json: { extra_users: extra_users, **context.as_json(json_setting) }
     end
 
     def context_params

--- a/audiences/app/controllers/audiences/scim_proxy_controller.rb
+++ b/audiences/app/controllers/audiences/scim_proxy_controller.rb
@@ -7,7 +7,7 @@ module Audiences
                                  .query(
                                    filter: "displayName co \"#{params[:filter]}\"",
                                    startIndex: params[:startIndex], count: params[:count],
-                                   attributes: "id,externalId,displayName,photos"
+                                   attributes: Audiences.exposed_user_attributes.join(",")
                                  )
 
       render json: resources, except: %w[schemas meta]

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -28,8 +28,8 @@ module Audiences
       where(user_id: attrs.pluck(:user_id))
     end
 
-    def as_json(*)
-      data.as_json(*)
+    def as_json(...)
+      data.as_json(...)
     end
   end
 end

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -29,7 +29,7 @@ module Audiences
     end
 
     def as_json(*)
-      data.as_json
+      data.as_json(*)
     end
   end
 end

--- a/audiences/app/models/audiences/users_search.rb
+++ b/audiences/app/models/audiences/users_search.rb
@@ -13,7 +13,7 @@ module Audiences
 
     def as_json(*)
       {
-        users: users,
+        users: users.as_json(*),
         count: count,
       }
     end

--- a/audiences/app/models/audiences/users_search.rb
+++ b/audiences/app/models/audiences/users_search.rb
@@ -11,9 +11,9 @@ module Audiences
       @offset = offset
     end
 
-    def as_json(*)
+    def as_json(...)
       {
-        users: users.as_json(*),
+        users: users.as_json(...),
         count: count,
       }
     end

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 1.5.2 (2024-12-19)
+
+- Filter sensitive user data out of user list response [#473](https://github.com/powerhome/audiences/pull/473)
+
 # Version 1.5.1 (2024-12-12)
 
 - Fix SCIM proxy attributes format [#462](https://github.com/powerhome/audiences/pull/462)

--- a/audiences/gemfiles/rails_6_1.gemfile.lock
+++ b/audiences/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.5.1)
+    audiences (1.5.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_7_0.gemfile.lock
+++ b/audiences/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.5.1)
+    audiences (1.5.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/gemfiles/rails_7_1.gemfile.lock
+++ b/audiences/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (1.5.1)
+    audiences (1.5.2)
       rails (>= 6.0)
 
 GEM

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -5,6 +5,13 @@ module Audiences
 
   # Configuration options
 
+  # These are the user attributes that will be exposed in the audiences endpoints.
+  # They're required by the UI to display the user information.
+  #
+  config_accessor :exposed_user_attributes do
+    %w[id externalId displayName photos]
+  end
+
   #
   # Authentication configuration. This defaults to true, meaning that the audiences
   # endpoints are open to the public.

--- a/audiences/lib/audiences/version.rb
+++ b/audiences/lib/audiences/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Audiences
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Audiences::ContextsController do
       criterion.users.create!([
                                 { user_id: 1, data: { "externalId" => 1, "displayName" => "John" } },
                                 { user_id: 2, data: { "externalId" => 2, "displayName" => "Jose" } },
-                                { user_id: 3, data: { "externalId" => 3, "displayName" => "Nelson" } },
+                                { user_id: 3, data: { "externalId" => 3, "displayName" => "Nelson", "confidential" => "data" } },
                               ])
 
       get :users, params: { key: example_context.signed_key, criterion_id: criterion.id }

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Audiences::ContextsController do
                 attributes: "id,externalId,displayName,active,photos.type,photos.value",
                 filter: "(active eq true) and (externalId eq 123)",
               })
-        .to_return(status: 200, body: { "Resources" => [{ "displayName" => "John Doe", "externalId" => 123 }] }.to_json)
+        .to_return(status: 200, body: { "Resources" => [{ "displayName" => "John Doe", "confidential" => "data", "externalId" => 123 }] }.to_json)
 
       put :update, params: {
         key: example_context.signed_key,
@@ -65,6 +65,7 @@ RSpec.describe Audiences::ContextsController do
       expect(example_context.extra_users).to eql [{
         "externalId" => 123,
         "displayName" => "John Doe",
+        "confidential" => "data",
       }]
       expect(response.parsed_body).to match({
                                               "match_all" => false,

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe Audiences::ContextsController do
                 attributes: "id,externalId,displayName,active,photos.type,photos.value",
                 filter: "(active eq true) and (externalId eq 123)",
               })
-        .to_return(status: 200, body: { "Resources" => [{ "displayName" => "John Doe", "confidential" => "data", "externalId" => 123 }] }.to_json)
+        .to_return(status: 200, body: { "Resources" => [{ "displayName" => "John Doe", "confidential" => "data",
+                                                          "externalId" => 123 }] }.to_json)
 
       put :update, params: {
         key: example_context.signed_key,

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -158,7 +158,8 @@ RSpec.describe Audiences::ContextsController do
       criterion.users.create!([
                                 { user_id: 1, data: { "externalId" => 1, "displayName" => "John" } },
                                 { user_id: 2, data: { "externalId" => 2, "displayName" => "Jose" } },
-                                { user_id: 3, data: { "externalId" => 3, "displayName" => "Nelson", "confidential" => "data" } },
+                                { user_id: 3,
+                                  data: { "externalId" => 3, "displayName" => "Nelson", "confidential" => "data" } },
                               ])
 
       get :users, params: { key: example_context.signed_key, criterion_id: criterion.id }


### PR DESCRIPTION
In previous PRs we started filtering out sensitive data on the SCIM proxy endpoint. The user endpoint also lists raw SCIM data and should be filtering the same attributes.