### PR TITLE
fix(auth): Mismatched authentication configuration names

### DIFF
--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -25,18 +25,18 @@ module Audiences
   # I.e.:
   #
   #   Audiences.configure do |config|
-  #     config.authentication = ->(*) { authenticate_request }
+  #     config.authenticate = ->(*) { authenticate_request }
   #   end
   #
   # I.e:
   #
   #   Audiences.configure do |config|
-  #     config.authentication = ->(request) do
+  #     config.authenticate = ->(request) do
   #       request.env["warden"].authenticate!
   #     end
   #   end
   #
-  config_accessor :authentication do
+  config_accessor :authenticate do
     ->(*) { true }
   end
 


### PR DESCRIPTION
The config and invocation mismatch on authenticate/authentication. If I follow the docs, or don't try to use the feature, I get:

```
│ audiences [dc4b3258-ee53-49e6-98da-277632a6e82f] LocalJumpError (no block given):                                                                              │
│ audiences [dc4b3258-ee53-49e6-98da-277632a6e82f]                                                                                                               │
│ audiences [dc4b3258-ee53-49e6-98da-277632a6e82f] audiences (1.5.3) app/controllers/audiences/application_controller.rb:12:in `instance_exec'                   │
│ audiences [dc4b3258-ee53-49e6-98da-277632a6e82f] audiences (1.5.3) app/controllers/audiences/application_controller.rb:12:in `authenticate!'
```

Broken in #438