### PR TITLE
Drop Ruby 3.0 from CI

### DIFF
--- a/.github/workflows/audiences-ruby.yml
+++ b/.github/workflows/audiences-ruby.yml
@@ -32,7 +32,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.0.7
           - 3.3
         gemfile:
           - gemfiles/rails_6_1.gemfile

--- a/audiences/gemfiles/rails_6_1.gemfile
+++ b/audiences/gemfiles/rails_6_1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal", "~> 2.5.0"
+gem "brakeman", "7.0.0"
 gem "debug", ">= 1.0.0"
 gem "foreman", "~> 0.88.0"
 gem "license_finder", ">= 7.0"

--- a/audiences/gemfiles/rails_6_1.gemfile.lock
+++ b/audiences/gemfiles/rails_6_1.gemfile.lock
@@ -74,6 +74,8 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     bigdecimal (3.1.8)
+    brakeman (7.0.0)
+      racc
     builder (3.3.0)
     concurrent-ruby (1.3.4)
     crack (1.0.0)
@@ -287,6 +289,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal (~> 2.5.0)
   audiences!
+  brakeman (= 7.0.0)
   debug (>= 1.0.0)
   foreman (~> 0.88.0)
   license_finder (>= 7.0)

--- a/audiences/gemfiles/rails_7_0.gemfile
+++ b/audiences/gemfiles/rails_7_0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal", "~> 2.5.0"
+gem "brakeman", "7.0.0"
 gem "debug", ">= 1.0.0"
 gem "foreman", "~> 0.88.0"
 gem "license_finder", ">= 7.0"

--- a/audiences/gemfiles/rails_7_0.gemfile.lock
+++ b/audiences/gemfiles/rails_7_0.gemfile.lock
@@ -80,6 +80,8 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     bigdecimal (3.1.8)
+    brakeman (7.0.0)
+      racc
     builder (3.3.0)
     concurrent-ruby (1.3.4)
     crack (1.0.0)
@@ -286,6 +288,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal (~> 2.5.0)
   audiences!
+  brakeman (= 7.0.0)
   debug (>= 1.0.0)
   foreman (~> 0.88.0)
   license_finder (>= 7.0)

--- a/audiences/gemfiles/rails_7_1.gemfile
+++ b/audiences/gemfiles/rails_7_1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 
 gem "appraisal", "~> 2.5.0"
+gem "brakeman", "7.0.0"
 gem "debug", ">= 1.0.0"
 gem "foreman", "~> 0.88.0"
 gem "license_finder", ">= 7.0"

--- a/audiences/gemfiles/rails_7_1.gemfile.lock
+++ b/audiences/gemfiles/rails_7_1.gemfile.lock
@@ -90,6 +90,8 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
+    brakeman (7.0.0)
+      racc
     builder (3.3.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -304,6 +306,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal (~> 2.5.0)
   audiences!
+  brakeman (= 7.0.0)
   debug (>= 1.0.0)
   foreman (~> 0.88.0)
   license_finder (>= 7.0)


### PR DESCRIPTION
`brakeman` was added as a requirement, but it does not support ruby < 3.1, so we're dropping that from CI. Our users are also on ruby 3.3 (connect, nitro, and runway).

- **Appraisal gems**
- **Remove ruby 3.0 from CI**
