### PR TITLE
Database caching for external user data

### DIFF
--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -13,10 +13,28 @@ module Audiences
     def self.fetch(external_ids, count: 100)
       return [] unless external_ids.any?
 
-      Array(external_ids).in_groups_of(count, false).flat_map do |ids|
-        filter = Array(ids).map { "externalId eq #{_1}" }.join(" OR ")
-        Audiences::Scim.resource(:Users).all(count: count, filter: filter).to_a
+      # Standardize the ids to an array of strings
+      ids = Array(external_ids).map(&:to_s)
+
+      # The local database is used as a cache for SCIM users, because this is significantly faster than querying SCIM
+      stored_users = Audiences::ExternalUser.where(user_id: ids)
+
+      missing_ids = ids - stored_users.map(&:user_id)
+      # If all users are already in the local database, return them without querying SCIM
+      return stored_users.map(&:data) if missing_ids.empty?
+
+      # Some users are missing from the local database, so we need to fetch them from SCIM
+      missing_ids.in_groups_of(count, false).each do |batch_ids|
+        filter = batch_ids.map { "externalId eq #{_1}" }.join(" OR ")
+        scim_users = Audiences::Scim.resource(:Users).all(count: count, filter: filter).to_a
+
+        next if scim_users.empty?
+        # Store the missing users
+        self.wrap(scim_users)
       end
+
+      new_users = Audiences::ExternalUser.where(user_id: missing_ids).to_a
+      stored_users.concat(new_users).map(&:data)
     end
 
     def self.wrap(resources)

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -17,7 +17,7 @@ module Audiences
       ids = Array(external_ids).map(&:to_s)
 
       # The local database is used as a cache for SCIM users, because this is significantly faster than querying SCIM
-      stored_users = Audiences::ExternalUser.where(user_id: ids)
+      stored_users = Audiences::ExternalUser.where(user_id: ids).to_a
 
       missing_ids = ids - stored_users.map(&:user_id)
       # If all users are already in the local database, return them without querying SCIM


### PR DESCRIPTION
This change improves performance of the ExternalUser.fetch method by:

1. Adding local database caching for external user data from SCIM
2. Only fetching users from SCIM when they're not already cached
3. If any users are missing, they're added to the database after being fetched from SCIM
4. The changes maintain backward compatibility with the original return format

Performance benefits:
- Significantly reduces external API calls to the SCIM service
- Improves response times, especially for repeated requests
- Reduces network overhead and latency
- Lowers load on the external SCIM service
- Scales better for applications making frequent user data requests

This approach maintains the same interface but drastically improves performance, particularly in high-volume environments where the same user data is requested multiple times.