### PR TITLE
[HFH-2913] Follow up - gem updated credentials

### DIFF
--- a/.github/workflows/audiences-ruby.yml
+++ b/.github/workflows/audiences-ruby.yml
@@ -125,6 +125,7 @@ jobs:
             :github: Bearer ${GITHUB_TOKEN}
             :rubygems_api_key: ${RUBYGEMS_API_KEY}
           EOF
+          chmod 0600 ~/.gem/credentials
           bundle exec rake build release:guard_clean release:rubygem_push
         working-directory: audiences
         env:


### PR DESCRIPTION
The /audiences-ruby.yml script is dynamically creating the ~/.gem/credentials file, but it’s likely that the file is being created with default permissions of 0644, which is too permissive for RubyGems. So adding the update to credentials to fit the acceptable permissions for RubyGems - 0600 should fix the error.

Fix to this error:
<img width="1131" alt="Screenshot 2025-03-19 at 3 51 35 PM" src="https://github.com/user-attachments/assets/56a5acd4-f843-420b-aa6a-5c032b17067d" />
