### PR TITLE
Bearer in Audiences

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,23 +18,3 @@ jobs:
           brakeman_version: gemfile
           tool_name: "audiences"
           workdir: "./audiences"
-  bearer:
-    name: Bearer
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1
-        with:
-          reviewdog_version: latest
-      - name: Bearer
-        uses: bearer/bearer-action@828eeb928ce2f4a7ca5ed57fb8b59508cb8c79bc # v2
-        with:
-          diff: true
-          format: rdjson
-          output: rd.json
-      - name: Run reviewdog
-        if: always()
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          touch rd.json && cat rd.json | reviewdog -f=rdjson -reporter=github-pr-check


### PR DESCRIPTION
See [our Security Standards](https://github.com/powerhome/bt-handbook/blob/main/docs/technical-standards/software-security-policy.md#bearer) for more information on why bearer is required in repos.