### PR TITLE
Default authentication to reject requests

### DIFF
--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -48,7 +48,20 @@ module Audiences
   #   end
   #
   config_accessor :authenticate do
-    ->(*) { true }
+    ->(*) do
+      Audiences.logger.warn(<<~MESSAGE)
+        Audiences authenticate is currently configured using a default and is blocking authenticaiton.
+
+        To make this wraning go away provide a configuration for `Audiences.config.authenticate`.
+
+        The value should:
+          1. Be callable like a Proc.
+          2. Return true when the request is permitted.
+          3. Return false when the request is not permitted.
+      MESSAGE
+
+      false
+    end
   end
 
   #


### PR DESCRIPTION
This change updates the default behavior of the authenticate configuration.

Instead of allowing all requests by default, the code now blocks authentication and warns the developer unless they explicitly configure authentication logic. This encourages users to implement proper authentication rather than relying on an insecure default.

**Previous behavior:**

The authenticate config was set to always return true, meaning authentication was always allowed by default.

**New behavior:**

The default authenticate config now logs a warning indicating that the default is being used and that authentication is being blocked.
The warning message provides instructions for properly configuring Audiences.config.authenticate with a custom Proc.
The default now returns false, blocking authentication by default until the user provides their own authentication logic.
