### PR TITLE
[SHD-1959] Reactive audience recalculation

### DIFF
--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -3,11 +3,11 @@
 module Audiences
   class ContextsController < ApplicationController
     def show
-      render_context Audiences::Context.load(params.require(:key))
+      render json: Audiences::Context.load(params.require(:key))
     end
 
     def update
-      render_context Audiences.update(params.require(:key), **context_params)
+      render json: Audiences.update(params.require(:key), **context_params)
     end
 
     def users
@@ -30,18 +30,6 @@ module Audiences
       return unless params[:criterion_id]
 
       @current_criterion ||= current_context.criteria.find(params[:criterion_id])
-    end
-
-    def render_context(context)
-      json_setting = {
-        only: %i[match_all],
-        methods: %i[count],
-        include: {
-          criteria: { only: %i[id groups], methods: %i[count] },
-        },
-      }
-
-      render json: { extra_users: context.extra_users, **context.as_json(json_setting) }
     end
 
     def context_params

--- a/audiences/app/jobs/audiences/application_job.rb
+++ b/audiences/app/jobs/audiences/application_job.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module Audiences
-  class ApplicationJob < ActiveJob::Base
-  end
-end

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -13,6 +13,11 @@ module Audiences
                         autosave: true,
                         dependent: :destroy
 
+    has_many :context_extra_users, class_name: "Audiences::ContextExtraUser"
+    has_many :extra_users, class_name: "Audiences::ExternalUser",
+                           through: :context_extra_users,
+                           source: :external_user
+
     scope :relevant_to, ->(group) do
       joins(:criteria).merge(Criterion.relevant_to(group))
     end
@@ -49,7 +54,7 @@ module Audiences
       return ExternalUser.all if match_all
 
       criteria_scope = criteria.any? ? ExternalUser.matching_any(*criteria) : ExternalUser.none
-      ExternalUser.from_scim(*extra_users).or(criteria_scope)
+      ExternalUser.where(id: extra_users.select(:id)).or(criteria_scope)
     end
   end
 end

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -26,6 +26,15 @@ module Audiences
 
     delegate :count, to: :users
 
+    def as_json(...)
+      {
+        match_all: match_all,
+        count: count,
+        extra_users: extra_users,
+        criteria: criteria,
+      }.as_json(...)
+    end
+
   private
 
     def notify_subscriptions

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -13,6 +13,10 @@ module Audiences
                         autosave: true,
                         dependent: :destroy
 
+    scope :relevant_to, ->(group) do
+      joins(:criteria).merge(Criterion.relevant_to(group))
+    end
+
     before_save if: :match_all do
       self.criteria = []
       self.extra_users = []

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -51,10 +51,15 @@ module Audiences
     end
 
     def matching_external_users
-      return ExternalUser.all if match_all
+      match_all ? ExternalUser.all : matching_extra_users.or(matching_criteria)
+    end
 
-      criteria_scope = criteria.any? ? ExternalUser.matching_any(*criteria) : ExternalUser.none
-      ExternalUser.where(id: extra_users.select(:id)).or(criteria_scope)
+    def matching_extra_users
+      ExternalUser.where(id: extra_users.select(:id))
+    end
+
+    def matching_criteria
+      criteria.any? ? ExternalUser.matching_any(*criteria) : ExternalUser.none
     end
   end
 end

--- a/audiences/app/models/audiences/context_extra_user.rb
+++ b/audiences/app/models/audiences/context_extra_user.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Audiences
+  class ContextExtraUser < ApplicationRecord
+    belongs_to :context
+    belongs_to :external_user
+  end
+end

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -5,6 +5,9 @@ module Audiences
     belongs_to :context, class_name: "Audiences::Context"
     validates :groups, presence: true
 
+    has_many :criterion_groups
+    has_many :groups, through: :criterion_groups
+
     def self.map(criteria)
       Array(criteria).map do |attrs|
         attrs["groups"] = attrs["groups"]&.to_h do |resource_type, groups|

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -17,6 +17,12 @@ module Audiences
       end
     end
 
+    def as_json(...)
+      groups = self.groups.group_by(&:resource_type)
+
+      { id: id, count: count, groups: groups }.as_json(...)
+    end
+
     def users
       Audiences::ExternalUser.matching(self)
                              .instance_exec(&Audiences.default_users_scope)

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -8,6 +8,10 @@ module Audiences
     has_many :criterion_groups
     has_many :groups, through: :criterion_groups
 
+    scope :relevant_to, ->(group) do
+      joins(:criterion_groups).where(criterion_groups: { group: group })
+    end
+
     # Maps an array of attribute hashes to Criterion objects.
     #
     # Each attribute hash should have a :groups key, whose value is a hash

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -5,7 +5,7 @@ module Audiences
     belongs_to :context, class_name: "Audiences::Context"
     validates :groups, presence: true
 
-    has_many :criterion_groups
+    has_many :criterion_groups, autosave: true, dependent: :destroy
     has_many :groups, through: :criterion_groups
 
     scope :relevant_to, ->(group) do

--- a/audiences/app/models/audiences/criterion_group.rb
+++ b/audiences/app/models/audiences/criterion_group.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Audiences
+  class CriterionGroup < ApplicationRecord
+    belongs_to :group
+    belongs_to :criterion
+  end
+end

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -3,7 +3,7 @@
 module Audiences
   class ExternalUser < ApplicationRecord
     has_many :group_memberships, dependent: :destroy
-    has_many :groups, through: :group_memberships
+    has_many :groups, through: :group_memberships, dependent: :destroy
 
     if Audiences.config.identity_class
       belongs_to :identity, class_name: Audiences.config.identity_class, # rubocop:disable Rails/ReflectionClassName

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -23,12 +23,13 @@ module Audiences
     end
 
     scope :matching, ->(criterion) do
-      groups = (criterion.try(:groups) || criterion).values.reject(&:empty?)
-      return none if groups.empty?
+      return none if criterion.groups.empty?
 
-      groups.reduce(self) do |scope, group|
-        group_ids = Audiences::Group.where(scim_id: group.pluck("id")).pluck(:id)
-        scope.where(id: Audiences::GroupMembership.where(group_id: group_ids).select(:external_user_id))
+      criterion.groups
+               .group_by(&:resource_type)
+               .values
+               .reduce(self) do |scope, groups|
+        scope.where(id: Audiences::GroupMembership.where(group_id: groups.pluck(:id)).select(:external_user_id))
       end
     end
 

--- a/audiences/app/models/audiences/group.rb
+++ b/audiences/app/models/audiences/group.rb
@@ -3,7 +3,7 @@
 module Audiences
   class Group < ApplicationRecord
     has_many :group_memberships, dependent: :destroy
-    has_many :external_users, through: :group_memberships
+    has_many :external_users, through: :group_memberships, dependent: :destroy
 
     validates :display_name, presence: true
     validates :external_id, presence: true

--- a/audiences/app/models/audiences/group_membership.rb
+++ b/audiences/app/models/audiences/group_membership.rb
@@ -4,5 +4,11 @@ module Audiences
   class GroupMembership < ApplicationRecord
     belongs_to :external_user
     belongs_to :group
+
+    after_commit on: %i[create destroy] do
+      relevant_groups = Audiences::Context.relevant_to(group)
+
+      Audiences::Notifications.publish(*relevant_groups.to_a)
+    end
   end
 end

--- a/audiences/db/migrate/20250620005528_create_audiences_criterion_groups.rb
+++ b/audiences/db/migrate/20250620005528_create_audiences_criterion_groups.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAudiencesCriterionGroups < ActiveRecord::Migration[6.1]
+  def change
+    create_table :audiences_criterion_groups do |t|
+      t.references :criterion, foreign_key: false
+      t.references :group, foreign_key: false
+
+      t.timestamps
+    end
+  end
+end

--- a/audiences/db/migrate/20250620005800_rename_audiences_criterion_groups_to_groups_json.rb
+++ b/audiences/db/migrate/20250620005800_rename_audiences_criterion_groups_to_groups_json.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameAudiencesCriterionGroupsToGroupsJson < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :audiences_criterions, :groups, :groups_json
+  end
+end

--- a/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
+++ b/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
@@ -3,10 +3,10 @@
 class MoveGroupCriterionToCriterionGroups < ActiveRecord::Migration[6.1]
   def up
     Audiences::Criterion.find_each do |criterion|
-      next if criterion.groups_json.empty?
+      next if criterion.groups_json.blank?
 
       groups = criterion.groups_json.values.flat_map do |scim_groups|
-        scim_groups.pluck(:id)
+        scim_groups.pluck("id")
       end
 
       criterion.update!(groups: Audiences::Group.where(scim_id: groups))

--- a/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
+++ b/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
@@ -1,0 +1,13 @@
+class MoveGroupCriterionToCriterionGroups < ActiveRecord::Migration[6.1]
+  def up
+    Audiences::Criterion.find_each do |criterion|
+      next if criterion.groups_json.empty?
+
+      groups = criterion.groups_json.values.flat_map do |scim_groups|
+        scim_groups.pluck(:id)
+      end
+
+      criterion.update!(groups: Audiences::Group.where(scim_id: groups))
+    end
+  end
+end

--- a/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
+++ b/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
@@ -12,4 +12,16 @@ class MoveGroupCriterionToCriterionGroups < ActiveRecord::Migration[6.1]
       criterion.update!(groups: Audiences::Group.where(scim_id: groups))
     end
   end
+
+  def down
+    Audiences::Criterion.find_each do |criterion|
+      next if criterion.groups.blank?
+
+      groups_json = criterion.groups.group_by(&:resource_type).transform_values do |groups|
+        groups.map(&:as_json)
+      end
+
+      criterion.update!(groups_json: groups_json)
+    end
+  end
 end

--- a/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
+++ b/audiences/db/migrate/20250623131202_move_group_criterion_to_criterion_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MoveGroupCriterionToCriterionGroups < ActiveRecord::Migration[6.1]
   def up
     Audiences::Criterion.find_each do |criterion|

--- a/audiences/db/migrate/20250624171247_create_audiences_context_extra_users.rb
+++ b/audiences/db/migrate/20250624171247_create_audiences_context_extra_users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAudiencesContextExtraUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :audiences_context_extra_users do |t|
+      t.references :external_user, foreign_key: false
+      t.references :context, foreign_key: false
+
+      t.timestamps
+    end
+  end
+end

--- a/audiences/db/migrate/20250624171706_rename_audiences_context_extra_users_to_extra_users_json.rb
+++ b/audiences/db/migrate/20250624171706_rename_audiences_context_extra_users_to_extra_users_json.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameAudiencesContextExtraUsersToExtraUsersJson < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :audiences_contexts, :extra_users, :extra_users_json
+  end
+end

--- a/audiences/db/migrate/20250701173946_move_extra_users_to_context_extra_users.rb
+++ b/audiences/db/migrate/20250701173946_move_extra_users_to_context_extra_users.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MoveExtraUsersToContextExtraUsers < ActiveRecord::Migration[6.1]
+  def up
+    Audiences::Context.find_each do |context|
+      next if context.extra_users_json.blank?
+
+      users = Audiences::ExternalUser.from_scim(*context.extra_users_json)
+
+      context.update!(extra_users: users)
+    end
+  end
+
+  def down
+    Audiences::Context.find_each do |context|
+      next if context.extra_users.blank?
+
+      context.update!(extra_users_json: context.extra_users.map(&:as_json))
+    end
+  end
+end

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -19,7 +19,7 @@ module_function
   # Params might contain:
   #
   # match_all: Boolean
-  # criteria: Array<{ <group_type>: Array<Integer> }>
+  # criteria: { groups: Array<{ <group_type>: Array<{ id: Integer }> }> }
   #
   # @param token [String] a signed token (see #sign)
   # @param params [Hash] the updated params

--- a/audiences/lib/audiences/notifications.rb
+++ b/audiences/lib/audiences/notifications.rb
@@ -29,8 +29,10 @@ module Audiences
     #
     # @param context [Audiences::Context] updated context
     #
-    def publish(context)
-      subscriptions[context.owner.class]&.call(context)
+    def publish(*contexts)
+      contexts.each do |context|
+        subscriptions[context.owner.class]&.call(context)
+      end
     end
   end
 end

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -179,8 +179,7 @@ RSpec.describe Audiences::ContextsController do
       user = create_user
       group = create_group(external_users: [user])
 
-      criterion = example_context.criteria.create(groups: { "Groups" => [{ "id" => group.scim_id,
-                                                                           "externalId" => group.external_id }] })
+      criterion = example_context.criteria.create(groups: [group])
 
       get :users, params: { key: example_context.signed_key, criterion_id: criterion.id }
 

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Audiences::ContextsController do
       expect(response.parsed_body).to match({
                                               "match_all" => false,
                                               "count" => 1,
-                                              "extra_users" => [user.data],
+                                              "extra_users" => [user],
                                               "criteria" => [],
-                                            })
+                                            }.as_json)
     end
 
     context "updating a group criteria" do
@@ -165,7 +165,7 @@ RSpec.describe Audiences::ContextsController do
 
       expect(response.parsed_body).to match({
                                               "count" => 3,
-                                              "users" => match_array(users.map(&:data)),
+                                              "users" => match_array(users.map(&:as_json)),
                                             })
     end
   end
@@ -185,8 +185,8 @@ RSpec.describe Audiences::ContextsController do
 
       expect(response.parsed_body).to match_array({
                                                     "count" => 1,
-                                                    "users" => [user.data],
-                                                  })
+                                                    "users" => [user],
+                                                  }.as_json)
     end
   end
 end

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -53,12 +53,8 @@ RSpec.describe Audiences::ContextsController do
       example_context.reload
 
       expect(example_context.extra_users).to match_array [user]
-      expect(response.parsed_body).to match({
-                                              "match_all" => false,
-                                              "count" => 1,
-                                              "extra_users" => [user.data],
-                                              "criteria" => [],
-                                            })
+      expect(response.parsed_body).to match({ "match_all" => false, "count" => 1, "extra_users" => [user],
+                                              "criteria" => [] }.as_json)
     end
 
     it "updates the context extra users using the externalId" do
@@ -159,10 +155,7 @@ RSpec.describe Audiences::ContextsController do
 
       get :users, params: { key: example_context.signed_key }
 
-      expect(response.parsed_body).to match({
-                                              "count" => 3,
-                                              "users" => match_array(users.map(&:as_json)),
-                                            })
+      expect(response.parsed_body).to match({ "count" => 3, "users" => users }.as_json)
     end
   end
 
@@ -179,7 +172,7 @@ RSpec.describe Audiences::ContextsController do
 
       get :users, params: { key: example_context.signed_key, criterion_id: criterion.id }
 
-      expect(response.parsed_body).to match_array({ "count" => 1, "users" => [user] }.as_json)
+      expect(response.parsed_body).to match({ "count" => 1, "users" => [user] }.as_json)
     end
   end
 end

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -72,12 +72,8 @@ RSpec.describe Audiences::ContextsController do
       example_context.reload
 
       expect(example_context.extra_users).to match_array [user]
-      expect(response.parsed_body).to match({
-                                              "match_all" => false,
-                                              "count" => 1,
-                                              "extra_users" => [user],
-                                              "criteria" => [],
-                                            }.as_json)
+      expect(response.parsed_body).to match({ "match_all" => false, "count" => 1, "extra_users" => [user],
+                                              "criteria" => [] }.as_json)
     end
 
     context "updating a group criteria" do
@@ -183,10 +179,7 @@ RSpec.describe Audiences::ContextsController do
 
       get :users, params: { key: example_context.signed_key, criterion_id: criterion.id }
 
-      expect(response.parsed_body).to match_array({
-                                                    "count" => 1,
-                                                    "users" => [user],
-                                                  }.as_json)
+      expect(response.parsed_body).to match_array({ "count" => 1, "users" => [user] }.as_json)
     end
   end
 end

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Audiences::ContextsController do
       expect(response.parsed_body).to match({
                                               "match_all" => false,
                                               "count" => 0,
-                                              "extra_users" => nil,
+                                              "extra_users" => [],
                                               "criteria" => [],
                                             })
     end
@@ -52,7 +52,7 @@ RSpec.describe Audiences::ContextsController do
 
       example_context.reload
 
-      expect(example_context.extra_users).to eql [user.data]
+      expect(example_context.extra_users).to match_array [user]
       expect(response.parsed_body).to match({
                                               "match_all" => false,
                                               "count" => 1,
@@ -71,7 +71,7 @@ RSpec.describe Audiences::ContextsController do
 
       example_context.reload
 
-      expect(example_context.extra_users).to eql [user.data]
+      expect(example_context.extra_users).to match_array [user]
       expect(response.parsed_body).to match({
                                               "match_all" => false,
                                               "count" => 1,
@@ -159,7 +159,7 @@ RSpec.describe Audiences::ContextsController do
     it "is the list of users from an audience context" do
       users = create_users 3
 
-      example_context.update(extra_users: users.map(&:data))
+      example_context.update(extra_users: users)
 
       get :users, params: { key: example_context.signed_key }
 

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_23_131202) do
+ActiveRecord::Schema.define(version: 2025_06_24_171706) do
+
+  create_table "audiences_context_extra_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "external_user_id"
+    t.bigint "context_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["context_id"], name: "index_audiences_context_extra_users_on_context_id"
+    t.index ["external_user_id"], name: "index_audiences_context_extra_users_on_external_user_id"
+  end
 
   create_table "audiences_contexts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "owner_type", null: false
@@ -18,7 +27,7 @@ ActiveRecord::Schema.define(version: 2025_06_23_131202) do
     t.boolean "match_all", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "extra_users"
+    t.json "extra_users_json"
     t.string "relation"
     t.index ["owner_type", "owner_id", "relation"], name: "index_audiences_contexts_on_owner_type_owner_id_relation", unique: true
   end

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_24_171706) do
+ActiveRecord::Schema.define(version: 2025_07_01_173946) do
 
   create_table "audiences_context_extra_users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "external_user_id"

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_18_184332) do
+ActiveRecord::Schema.define(version: 2025_06_20_005800) do
 
   create_table "audiences_contexts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "owner_type", null: false
@@ -23,8 +23,17 @@ ActiveRecord::Schema.define(version: 2025_06_18_184332) do
     t.index ["owner_type", "owner_id", "relation"], name: "index_audiences_contexts_on_owner_type_owner_id_relation", unique: true
   end
 
+  create_table "audiences_criterion_groups", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "criterion_id"
+    t.bigint "group_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["criterion_id"], name: "index_audiences_criterion_groups_on_criterion_id"
+    t.index ["group_id"], name: "index_audiences_criterion_groups_on_group_id"
+  end
+
   create_table "audiences_criterions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.json "groups"
+    t.json "groups_json"
     t.bigint "context_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/audiences/spec/dummy/db/schema.rb
+++ b/audiences/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_06_20_005800) do
+ActiveRecord::Schema.define(version: 2025_06_23_131202) do
 
   create_table "audiences_contexts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "owner_type", null: false

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -36,8 +36,7 @@ RSpec.describe Audiences do
       )
 
       expect(updated_context.criteria.size).to eql(1)
-      expect(updated_context.criteria.first.groups).to match({ "Departments" => [department1.as_json,
-                                                                                 department2.as_json] })
+      expect(updated_context.criteria.first.groups).to match_array [department1, department2]
 
       updated_context = Audiences.update(
         token,
@@ -49,9 +48,8 @@ RSpec.describe Audiences do
       )
 
       expect(updated_context.criteria.size).to eql(2)
-      expect(updated_context.criteria.first.groups).to match({ "Departments" => [department1, department2].as_json,
-                                                               "Territories" => [territory1, territory2].as_json })
-      expect(updated_context.criteria.last.groups).to match({ "Titles" => [title1, title2].as_json })
+      expect(updated_context.criteria.first.groups).to match_array [department1, department2, territory1, territory2]
+      expect(updated_context.criteria.last.groups).to match_array [title1, title2]
     end
   end
 end

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Audiences do
       user1, user2 = create_users(2)
 
       updated_context = Audiences.update(token, extra_users: [{ "id" => user1.scim_id }, { "id" => user2.scim_id }])
-      expect(updated_context.extra_users).to eql([user1.data, user2.data])
+      expect(updated_context.extra_users).to match_array([user1, user2])
     end
 
     it "updates group criterion" do

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Audiences::Context do
 
       expect(owner.members_external_users).to match_array extra_users
 
-      owner.members_context.criteria.create!(groups: { "Groups" => [group2] }.as_json)
+      owner.members_context.criteria.create!(groups: [group2])
 
       expect(owner.members_external_users).to match_array extra_users + group_users
     end
@@ -53,7 +53,7 @@ RSpec.describe Audiences::Context do
 
       expect(owner.members_external_users).to match_array [active_extra_user]
 
-      owner.members_context.criteria.create!(groups: { "Groups" => [group2] }.as_json)
+      owner.members_context.criteria.create!(groups: [group2])
 
       expect(owner.members_external_users).to match_array [active_extra_user, active_group_user]
     end
@@ -62,7 +62,7 @@ RSpec.describe Audiences::Context do
       extra_users = create_users(3)
 
       owner.save
-      owner.members_context.update!(extra_users: extra_users.map(&:as_json), match_all: false)
+      owner.members_context.update!(extra_users: extra_users, match_all: false)
 
       expect(owner.members_external_users).to match_array extra_users
     end

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Audiences::Context do
 
   describe "#match_all" do
     it "clears other criteria when set to match all" do
-      owner.members_context.criteria.build(groups: { Departments: [1, 3, 4] })
+      owner.members_context.criteria.build(groups: create_groups(1))
       owner.members_context.match_all = true
 
       owner.members_context.save!

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -70,21 +70,24 @@ RSpec.describe Audiences::Context do
 
   describe "#match_all" do
     it "clears other criteria when set to match all" do
-      owner.members_context.criteria.build(groups: create_groups(1))
-      owner.members_context.match_all = true
+      context = create_context(extra_users: create_users(2))
+      create_criterion(context: context, groups: create_groups(1))
 
-      owner.members_context.save!
+      expect(context.criteria.size).to eql 1
 
-      expect(owner.members_context.criteria).to be_empty
+      context.update!(match_all: true)
+
+      expect(context.criteria).to be_empty
     end
 
     it "clears extra users when set to match all" do
-      owner.members_context.extra_users = [{ "id" => 123 }]
-      owner.members_context.match_all = true
+      context = create_context(extra_users: create_users(2))
 
-      owner.members_context.save!
+      expect(context.extra_users.size).to eql 2
 
-      expect(owner.members_context.extra_users).to be_empty
+      context.update!(match_all: true)
+
+      expect(context.extra_users).to be_empty
     end
   end
 
@@ -94,7 +97,9 @@ RSpec.describe Audiences::Context do
 
   describe "#count" do
     it "is the total of all member users" do
-      owner.members_context.update(extra_users: create_users(2).map(&:data))
+      owner.save!
+
+      owner.members_context.update(extra_users: create_users(2))
 
       expect(owner.members_context.count).to eql 2
     end

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Audiences::Criterion do
 
   describe "validations" do
     it "does not allow criterion groups with empty groups" do
-      criterion = Audiences::Criterion.new(groups: {})
+      criterion = Audiences::Criterion.new(groups: [])
       expect(criterion).not_to be_valid
       expect(criterion.errors[:groups]).to include("can't be blank")
     end
@@ -42,7 +42,7 @@ RSpec.describe Audiences::Criterion do
       )
 
       expect(criteria.size).to eql 1
-      expect(criteria.first.groups).to match({ "Departments" => [department.as_json] })
+      expect(criteria.first.groups).to match_array([department])
     end
   end
 

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Audiences::Criterion do
       )
 
       expect(criteria.size).to eql 2
-      expect(criteria.first.groups).to match({ "Departments" => [department.as_json] })
-      expect(criteria.last.groups).to match({ "Territories" => [territory.as_json] })
+      expect(criteria.first.groups).to match_array [department]
+      expect(criteria.last.groups).to match_array [territory]
     end
 
     it "allows setting creating groups not matching the default group scope" do

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe Audiences::Criterion do
     end
   end
 
+  describe ".relevant_to" do
+    it "returns criteria relevant to the given group" do
+      group1, group2 = create_groups(2)
+      criterion1 = create_criterion(groups: [group1])
+      criterion2 = create_criterion(groups: [group2])
+      criterion3 = create_criterion(groups: [group1, group2])
+      create_criterion(groups: [])
+
+      expect(Audiences::Criterion.relevant_to(group1)).to match_array [criterion1, criterion3]
+      expect(Audiences::Criterion.relevant_to(group2)).to match_array [criterion2, criterion3]
+    end
+  end
+
   describe ".map([])" do
     it "builds contexts with the given " do
       department = create_group(resource_type: "Departments")

--- a/audiences/spec/models/audiences/external_user_spec.rb
+++ b/audiences/spec/models/audiences/external_user_spec.rb
@@ -37,35 +37,19 @@ RSpec.describe Audiences::ExternalUser, :aggregate_failures do
       _department2 = create_group(resource_type: "Departments", external_users: [user3])
       department3 = create_group(resource_type: "Departments", external_users: [user4])
 
-      users = Audiences::ExternalUser.matching(
-        "Departments" => [{ "id" => department1.scim_id }, { "id" => department3.scim_id }],
-        "Titles" => [{ "id" => title1.scim_id }, { "id" => title2.scim_id }]
-      )
+      criterion = create_criterion(groups: [department1, department3, title1, title2])
+
+      users = Audiences::ExternalUser.matching(criterion)
 
       expect(users.pluck(:id)).to match_array [user1.id, user4.id]
     end
 
     it "ignores empty group types" do
-      user1, user2, user3, user4 = create_users(4)
+      create_users(4)
 
-      _title1 = create_group(resource_type: "Titles", external_users: [user1, user2])
-      _title2 = create_group(resource_type: "Titles", external_users: [user3, user4])
-      department1 = create_group(resource_type: "Departments", external_users: [user1, user2])
-      _department2 = create_group(resource_type: "Departments", external_users: [user3, user4])
-      _department3 = create_group(resource_type: "Departments", external_users: [user4])
+      criterion = create_criterion(groups: [])
 
-      users = Audiences::ExternalUser.matching(
-        "Departments" => [{ "id" => department1.scim_id }],
-        "Titles" => []
-      )
-
-      expect(users.pluck(:id)).to match_array [user1.id, user2.id]
-    end
-
-    it "ignores invalid criterion" do
-      create_users(3)
-
-      users = Audiences::ExternalUser.matching("Departments" => [])
+      users = Audiences::ExternalUser.matching(criterion)
 
       expect(users).to be_empty
     end
@@ -79,10 +63,10 @@ RSpec.describe Audiences::ExternalUser, :aggregate_failures do
       title2 = create_group(resource_type: "Titles", external_users: [user3])
       department1 = create_group(resource_type: "Departments", external_users: [user1, user3, user4])
 
-      users = Audiences::ExternalUser.matching_any(
-        { "Departments" => [{ "id" => department1.scim_id }], "Titles" => [{ "id" => title1.scim_id }] },
-        { "Departments" => [{ "id" => department1.scim_id }], "Titles" => [{ "id" => title2.scim_id }] }
-      )
+      criterion1 = create_criterion(groups: [department1, title1])
+      criterion2 = create_criterion(groups: [department1, title2])
+
+      users = Audiences::ExternalUser.matching_any(criterion1, criterion2)
 
       expect(users).to match_array [user1, user3]
     end
@@ -93,10 +77,10 @@ RSpec.describe Audiences::ExternalUser, :aggregate_failures do
       title1 = create_group(resource_type: "Titles", external_users: [user1, user2])
       department1 = create_group(resource_type: "Departments", external_users: [user1, user3, user4])
 
-      users = Audiences::ExternalUser.matching_any(
-        { "Departments" => [{ "id" => department1.scim_id }], "Titles" => [{ "id" => title1.scim_id }] },
-        { "Departments" => [], "Titles" => [] }
-      )
+      criterion1 = create_criterion(groups: [department1, title1])
+      criterion2 = create_criterion(groups: [])
+
+      users = Audiences::ExternalUser.matching_any(criterion1, criterion2)
 
       expect(users).to match_array [user1]
     end

--- a/audiences/spec/models/audiences/external_user_spec.rb
+++ b/audiences/spec/models/audiences/external_user_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Audiences::ExternalUser, :aggregate_failures do
+  describe "associations" do
+    it { is_expected.to have_many(:group_memberships).dependent(:destroy) }
+    it { is_expected.to have_many(:groups).through(:group_memberships).dependent(:destroy) }
+  end
+
   describe ".search(query)" do
     it "returns users matching the query" do
       user1 = create_user(display_name: "Alice Smith")

--- a/audiences/spec/models/audiences/group_membership_spec.rb
+++ b/audiences/spec/models/audiences/group_membership_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Audiences::GroupMembership do
+  describe "associations" do
+    it { is_expected.to belong_to(:external_user) }
+    it { is_expected.to belong_to(:group) }
+  end
+
+  describe "after_commit callbacks" do
+    let(:group) { create_group }
+    let(:external_user) { create_user }
+
+    it "publishes notifications for relevant contexts" do
+      relevant_criterion = create_criterion(groups: [group])
+
+      expect(Audiences::Notifications).to receive(:publish).with(relevant_criterion.context)
+
+      Audiences::GroupMembership.create!(external_user: external_user, group: group)
+    end
+  end
+end

--- a/audiences/spec/models/audiences/group_spec.rb
+++ b/audiences/spec/models/audiences/group_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Audiences::Group, :aggregate_failures do
+  describe "associations" do
+    it { is_expected.to have_many(:group_memberships).dependent(:destroy) }
+    it { is_expected.to have_many(:external_users).through(:group_memberships).dependent(:destroy) }
+  end
+
+  describe ".search(query)" do
+    it "returns users matching the query" do
+      group1 = create_group(display_name: "Gropu Abc")
+      group2 = create_group(display_name: "Gropu LOL")
+      group3 = create_group(display_name: "Gropu YEY")
+
+      results = Audiences::Group.search("LOL")
+
+      expect(results).to contain_exactly(group2)
+      expect(results).not_to include(group1, group3)
+    end
+
+    it "performs a case insensitive search" do
+      group1 = create_group(display_name: "Gropu Abc")
+      group2 = create_group(display_name: "Gropu LOL")
+      group3 = create_group(display_name: "Gropu Abc")
+
+      results = Audiences::Group.search("lol")
+
+      expect(results).to contain_exactly(group2)
+      expect(results).not_to include(group1, group3)
+    end
+  end
+end

--- a/audiences/spec/models/audiences/model_spec.rb
+++ b/audiences/spec/models/audiences/model_spec.rb
@@ -15,21 +15,18 @@ RSpec.describe Audiences::Model do
     it "is the collection of identity objects from the context users" do
       example_users = Array.new(3) { ExampleUser.create(name: "User #{_1}") }
       external_users = example_users.map { create_user(user_id: _1.id) }
+      context = create_context(extra_users: external_users)
 
-      subject.members_context.update(extra_users: external_users.map(&:data))
-
-      expect(subject.members).to match_array example_users
+      expect(context.owner.members).to match_array example_users
     end
   end
 
   describe "#relation_name_external_users" do
-    it "is the collection of identity objects from the context users" do
-      example_users = Array.new(3) { ExampleUser.create(name: "User #{_1}") }
-      external_users = example_users.map { create_user(user_id: _1.id) }
+    it "is the collection of external users objects from the context users" do
+      external_users = create_users(2)
+      context = create_context(extra_users: external_users)
 
-      subject.members_context.update(extra_users: external_users.map(&:data))
-
-      expect(subject.members_external_users).to match_array external_users
+      expect(context.owner.members_external_users).to match_array external_users
     end
   end
 

--- a/audiences/spec/support/factories.rb
+++ b/audiences/spec/support/factories.rb
@@ -13,10 +13,10 @@ module Audiences
                                  external_id: scim_id, resource_type: resource_type, **attrs)
       end
 
-      def create_user(scim_id: next_scim_id, **attrs)
-        data = { "id" => scim_id, "externalId" => scim_id, "displayName" => "User #{scim_id}" }
+      def create_user(scim_id: next_scim_id, user_id: scim_id, **attrs)
+        data = { "id" => scim_id, "externalId" => user_id, "displayName" => "User #{scim_id}" }
         Audiences::ExternalUser.create!(scim_id: scim_id, display_name: data["displayName"],
-                                        user_id: data["externalId"], data: data, **attrs)
+                                        user_id: user_id, data: data, **attrs)
       end
 
       def create_example_owner

--- a/audiences/spec/support/factories.rb
+++ b/audiences/spec/support/factories.rb
@@ -24,7 +24,9 @@ module Audiences
       end
 
       def create_context(owner: create_example_owner, **attrs)
-        Audiences::Context.create(owner: owner, **attrs)
+        owner.members_context.tap do |context|
+          context.update!(attrs)
+        end
       end
 
       def create_criterion(context: create_context, **attrs)

--- a/audiences/spec/support/factories.rb
+++ b/audiences/spec/support/factories.rb
@@ -19,8 +19,24 @@ module Audiences
                                         user_id: data["externalId"], data: data, **attrs)
       end
 
+      def create_example_owner
+        ExampleOwner.create
+      end
+
+      def create_context(owner: create_example_owner, **attrs)
+        Audiences::Context.create(owner: owner, **attrs)
+      end
+
+      def create_criterion(context: create_context, **attrs)
+        context.criteria.create(**attrs)
+      end
+
       def create_users(number, **attrs)
         Array.new(number) { create_user(**attrs) }
+      end
+
+      def create_groups(number, **attrs)
+        Array.new(number) { create_group(**attrs) }
       end
     end
   end


### PR DESCRIPTION
[SHD-1359](https://runway.powerhrg.com/backlog_items/SHD-1359)

This pull request introduces significant changes to the audiences context and criteria/group association logic, refactoring how group criteria are handled, stored, and queried. Here’s a summary of the main changes:

- Moves from storing group info as JSON directly on criteria to a proper join table (audiences_criterion_groups).
- Refactors queries, associations, and serialization to use ActiveRecord associations.
- Updates controller, model, and test code accordingly.
- Adds new database migrations for the join table and column rename.
- Cleans up and improves group membership notification logic.