### PR TITLE
Allow creating external users and groups with internal and external ids

### DIFF
--- a/audiences/app/controllers/audiences/contexts_controller.rb
+++ b/audiences/app/controllers/audiences/contexts_controller.rb
@@ -48,7 +48,7 @@ module Audiences
       params.permit(
         :match_all,
         criteria: [groups: {}],
-        extra_users: %i[id]
+        extra_users: %i[id externalId]
       ).to_h.symbolize_keys
     end
   end

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -18,7 +18,7 @@ module Audiences
       self.extra_users = []
     end
 
-    after_commit :notify_subscriptions
+    after_commit :notify_subscriptions, on: :update
 
     def users
       @users ||= matching_external_users

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -6,7 +6,12 @@ module Audiences
     validates :groups, presence: true
 
     def self.map(criteria)
-      Array(criteria).map { new(_1) }
+      Array(criteria).map do |attrs|
+        attrs["groups"] = attrs["groups"]&.to_h do |resource_type, groups|
+          [resource_type, Audiences::Group.from_scim(resource_type, *groups).as_json]
+        end
+        new(attrs)
+      end
     end
 
     def users

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -20,7 +20,8 @@ module Audiences
     end
 
     scope :from_scim, ->(*scim_json) do
-      where(scim_id: scim_json&.pluck("id"))
+      where(scim_id: scim_json.pluck("id").compact)
+        .or(where(user_id: scim_json.pluck("externalId").compact))
     end
 
     scope :matching, ->(criterion) do

--- a/audiences/app/models/audiences/group.rb
+++ b/audiences/app/models/audiences/group.rb
@@ -15,6 +15,11 @@ module Audiences
       where(arel_table[:display_name].matches("%#{display_name}%"))
     end
 
+    scope :from_scim, ->(resource_type, *scim_json) do
+      where(scim_id: scim_json.pluck("id"))
+        .or(where(resource_type: resource_type, external_id: scim_json.pluck("externalId")))
+    end
+
     def as_json(...)
       { "id" => scim_id, "externalId" => external_id, "displayName" => display_name }.as_json(...)
     end

--- a/audiences/lib/audiences.rb
+++ b/audiences/lib/audiences.rb
@@ -29,8 +29,8 @@ module_function
     Audiences::Context.load(key) do |context|
       context.update!(
         match_all: match_all,
-        extra_users: ::Audiences::ExternalUser.from_scim(*extra_users).map(&:as_json),
-        criteria: ::Audiences::Criterion.map(criteria)
+        extra_users: ::Audiences::ExternalUser.from_scim(*extra_users.map(&:with_indifferent_access)),
+        criteria: ::Audiences::Criterion.map(criteria.map(&:with_indifferent_access))
       )
     end
   end

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -110,9 +110,40 @@ RSpec.describe Audiences::ContextsController do
                                                     "id" => anything,
                                                     "count" => 2,
                                                     "groups" => {
-                                                      "Departments" => [{ "id" => department.scim_id }],
-                                                      "Territories" => [{ "id" => territory.scim_id }],
-                                                    },
+                                                      "Departments" => [department],
+                                                      "Territories" => [territory],
+                                                    }.as_json,
+                                                  },
+                                                ],
+                                              })
+      end
+
+      it "allows updating the group criteria with group external ids" do
+        users = create_users(2)
+        department = create_group(resource_type: "Departments", external_users: users)
+        territory = create_group(resource_type: "Territories", external_users: users)
+
+        put :update, params: {
+          key: example_context.signed_key,
+          match_all: false,
+          criteria: [
+            { groups: { Departments: [{ externalId: department.external_id }],
+                        Territories: [{ externalId: territory.external_id }] } },
+          ],
+        }
+
+        expect(response.parsed_body).to match({
+                                                "match_all" => false,
+                                                "extra_users" => [],
+                                                "count" => 2,
+                                                "criteria" => [
+                                                  {
+                                                    "id" => anything,
+                                                    "count" => 2,
+                                                    "groups" => {
+                                                      "Departments" => [department],
+                                                      "Territories" => [territory],
+                                                    }.as_json,
                                                   },
                                                 ],
                                               })

--- a/audiences/spec/controllers/contexts_controller_spec.rb
+++ b/audiences/spec/controllers/contexts_controller_spec.rb
@@ -42,12 +42,31 @@ RSpec.describe Audiences::ContextsController do
       expect(example_context.users.count).to eq(5)
     end
 
-    it "updates the context extra users" do
+    it "updates the context extra users scim id" do
       user = create_user
 
       put :update, params: {
         key: example_context.signed_key,
-        extra_users: [user.data],
+        extra_users: [user.data.slice("id")],
+      }
+
+      example_context.reload
+
+      expect(example_context.extra_users).to eql [user.data]
+      expect(response.parsed_body).to match({
+                                              "match_all" => false,
+                                              "count" => 1,
+                                              "extra_users" => [user.data],
+                                              "criteria" => [],
+                                            })
+    end
+
+    it "updates the context extra users using the externalId" do
+      user = create_user
+
+      put :update, params: {
+        key: example_context.signed_key,
+        extra_users: [user.data.slice("externalId")],
       }
 
       example_context.reload

--- a/audiences/spec/lib/audiences_spec.rb
+++ b/audiences/spec/lib/audiences_spec.rb
@@ -21,29 +21,37 @@ RSpec.describe Audiences do
     end
 
     it "updates group criterion" do
+      department1 = create_group(resource_type: "Departments")
+      department2 = create_group(resource_type: "Departments")
+      territory1 = create_group(resource_type: "Territories")
+      territory2 = create_group(resource_type: "Territories")
+      title1 = create_group(resource_type: "Titles")
+      title2 = create_group(resource_type: "Titles")
+
       updated_context = Audiences.update(
         token,
         criteria: [
-          { groups: { Departments: [{ id: 3 }, { id: 4 }] } },
+          { "groups" => { "Departments" => [{ "id" => department1.scim_id }, { "id" => department2.scim_id }] } },
         ]
       )
 
       expect(updated_context.criteria.size).to eql(1)
-      expect(updated_context.criteria.first.groups).to match({ "Departments" => [{ "id" => 3 }, { "id" => 4 }] })
+      expect(updated_context.criteria.first.groups).to match({ "Departments" => [department1.as_json,
+                                                                                 department2.as_json] })
 
       updated_context = Audiences.update(
         token,
         criteria: [
-          { groups: { Departments: [{ id: 1 }, { id: 2 }], Territories: [{ id: 3 }, { id: 4 }] } },
-          { groups: { Branches: [{ id: 5 }, { id: 6 }], Titles: [{ id: 7 }, { id: 8 }] } },
+          { "groups" => { "Departments" => [{ "id" => department1.scim_id }, { "id" => department2.scim_id }],
+                          "Territories" => [{ "id" => territory1.scim_id }, { "id" => territory2.scim_id }] } },
+          { "groups" => { "Titles" => [{ "id" => title1.scim_id }, { "id" => title2.scim_id }] } },
         ]
       )
 
       expect(updated_context.criteria.size).to eql(2)
-      expect(updated_context.criteria.first.groups).to match({ "Departments" => [{ "id" => 1 }, { "id" => 2 }],
-                                                               "Territories" => [{ "id" => 3 }, { "id" => 4 }] })
-      expect(updated_context.criteria.last.groups).to match({ "Branches" => [{ "id" => 5 }, { "id" => 6 }],
-                                                              "Titles" => [{ "id" => 7 }, { "id" => 8 }] })
+      expect(updated_context.criteria.first.groups).to match({ "Departments" => [department1, department2].as_json,
+                                                               "Territories" => [territory1, territory2].as_json })
+      expect(updated_context.criteria.last.groups).to match({ "Titles" => [title1, title2].as_json })
     end
   end
 end

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 RSpec.describe Audiences::Context do
-  let(:owner) { ExampleOwner.new(name: "Example") }
+  let(:owner) { ExampleOwner.create(name: "Example") }
 
-  describe "#save" do
-    it "publishes a notification about the context update" do
+  describe "context notification" do
+    it "publishes a notification about the context updates" do
       expect do |blk|
         Audiences::Notifications.subscribe ExampleOwner, &blk
-        owner.save!
+        owner.members_context.update!(match_all: true)
       end.to yield_with_args(owner.members_context)
     end
   end
@@ -19,7 +19,7 @@ RSpec.describe Audiences::Context do
       owner.members_context.criteria.build(groups: { Departments: [1, 3, 4] })
       owner.members_context.match_all = true
 
-      owner.save!
+      owner.members_context.save!
 
       expect(owner.members_context.criteria).to be_empty
     end
@@ -28,7 +28,7 @@ RSpec.describe Audiences::Context do
       owner.members_context.extra_users = [{ "id" => 123 }]
       owner.members_context.match_all = true
 
-      owner.save!
+      owner.members_context.save!
 
       expect(owner.members_context.extra_users).to be_empty
     end
@@ -40,8 +40,6 @@ RSpec.describe Audiences::Context do
 
   describe "#count" do
     it "is the total of all member users" do
-      owner.save!
-
       owner.members_context.update(extra_users: create_users(2).map(&:data))
 
       expect(owner.members_context.count).to eql 2

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -9,16 +9,19 @@ RSpec.describe Audiences::Criterion do
 
   describe ".map([])" do
     it "builds contexts with the given " do
+      department = create_group(resource_type: "Departments")
+      territory = create_group(resource_type: "Territories")
+
       criteria = Audiences::Criterion.map(
         [
-          { groups: { Departments: [{ id: 1 }] } },
-          { groups: { Territories: [{ id: 3 }] } },
+          { "groups" => { "Departments" => [department.as_json] } },
+          { "groups" => { "Territories" => [territory.as_json] } },
         ]
       )
 
       expect(criteria.size).to eql 2
-      expect(criteria.first.groups).to match({ "Departments" => [{ "id" => 1 }] })
-      expect(criteria.last.groups).to match({ "Territories" => [{ "id" => 3 }] })
+      expect(criteria.first.groups).to match({ "Departments" => [department.as_json] })
+      expect(criteria.last.groups).to match({ "Territories" => [territory.as_json] })
     end
   end
 


### PR DESCRIPTION
Nitro only has access to the `externalId`. And to avoid one trip to the SCIM service to fetch internal IDs, accepting `externalId` will improve the current process while the bridge is in place. Once the bridge is gone, we should be able to remove support for this.