### PR TITLE
[SHD-1390] Allow inactive groups in criteria

### DIFF
--- a/audiences/app/controllers/audiences/scim_proxy_controller.rb
+++ b/audiences/app/controllers/audiences/scim_proxy_controller.rb
@@ -14,9 +14,10 @@ module Audiences
 
     def scope
       if params[:scim_path].eql?("Users")
-        Audiences::ExternalUser
+        Audiences::ExternalUser.instance_exec(&Audiences.default_users_scope)
       else
         Audiences::Group.where(resource_type: params[:scim_path])
+                        .instance_exec(&Audiences.default_groups_scope)
       end
     end
   end

--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -21,7 +21,7 @@ module Audiences
     after_commit :notify_subscriptions, on: :update
 
     def users
-      @users ||= matching_external_users
+      matching_external_users.instance_exec(&Audiences.default_users_scope)
     end
 
     delegate :count, to: :users

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -15,7 +15,8 @@ module Audiences
     end
 
     def users
-      @users ||= Audiences::ExternalUser.matching(self)
+      Audiences::ExternalUser.matching(self)
+                             .instance_exec(&Audiences.default_users_scope)
     end
 
     delegate :count, to: :users

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -8,7 +8,7 @@ module Audiences
     def self.map(criteria)
       Array(criteria).map do |attrs|
         attrs["groups"] = attrs["groups"]&.to_h do |resource_type, groups|
-          [resource_type, Audiences::Group.unscoped.from_scim(resource_type, *groups).as_json]
+          [resource_type, Audiences::Group.from_scim(resource_type, *groups).as_json]
         end
         new(attrs)
       end

--- a/audiences/app/models/audiences/criterion.rb
+++ b/audiences/app/models/audiences/criterion.rb
@@ -8,7 +8,7 @@ module Audiences
     def self.map(criteria)
       Array(criteria).map do |attrs|
         attrs["groups"] = attrs["groups"]&.to_h do |resource_type, groups|
-          [resource_type, Audiences::Group.from_scim(resource_type, *groups).as_json]
+          [resource_type, Audiences::Group.unscoped.from_scim(resource_type, *groups).as_json]
         end
         new(attrs)
       end

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -26,6 +26,8 @@ module Audiences
 
     scope :matching, ->(criterion) do
       groups = (criterion.try(:groups) || criterion).values.reject(&:empty?)
+      return none if groups.empty?
+
       groups.reduce(self) do |scope, group|
         group_ids = Audiences::Group.where(scim_id: group.pluck("id")).pluck(:id)
         scope.where(id: Audiences::GroupMembership.where(group_id: group_ids).select(:external_user_id))

--- a/audiences/app/models/audiences/external_user.rb
+++ b/audiences/app/models/audiences/external_user.rb
@@ -2,8 +2,6 @@
 
 module Audiences
   class ExternalUser < ApplicationRecord
-    default_scope Audiences.default_users_scope
-
     has_many :group_memberships, dependent: :destroy
     has_many :groups, through: :group_memberships
 

--- a/audiences/app/models/audiences/group.rb
+++ b/audiences/app/models/audiences/group.rb
@@ -2,8 +2,6 @@
 
 module Audiences
   class Group < ApplicationRecord
-    default_scope Audiences.default_groups_scope
-
     has_many :group_memberships, dependent: :destroy
     has_many :external_users, through: :group_memberships
 

--- a/audiences/lib/audiences/scim/patch_groups_observer.rb
+++ b/audiences/lib/audiences/scim/patch_groups_observer.rb
@@ -31,8 +31,8 @@ module Audiences
       end
 
       def group
-        @group ||= Audiences::Group.unscoped.find_by!(resource_type: event_payload.resource,
-                                                      scim_id: event_payload.id)
+        @group ||= Group.find_by!(resource_type: event_payload.resource,
+                                  scim_id: event_payload.id)
       end
     end
   end

--- a/audiences/lib/audiences/scim/patch_users_observer.rb
+++ b/audiences/lib/audiences/scim/patch_users_observer.rb
@@ -31,7 +31,7 @@ module Audiences
       end
 
       def user
-        @user ||= Audiences::ExternalUser.unscoped.find_by!(scim_id: event_payload.id)
+        @user ||= Audiences::ExternalUser.find_by!(scim_id: event_payload.id)
       end
     end
   end

--- a/audiences/lib/audiences/scim/upsert_groups_observer.rb
+++ b/audiences/lib/audiences/scim/upsert_groups_observer.rb
@@ -31,8 +31,7 @@ module Audiences
       end
 
       def group
-        @group ||= Audiences::Group.unscoped
-                                   .where(resource_type: event_payload.resource,
+        @group ||= Audiences::Group.where(resource_type: event_payload.resource,
                                           scim_id: event_payload.params["id"])
                                    .first_or_initialize
       end

--- a/audiences/lib/audiences/scim/upsert_users_observer.rb
+++ b/audiences/lib/audiences/scim/upsert_users_observer.rb
@@ -20,7 +20,7 @@ module Audiences
       def scim_id = event_payload.params["id"]
 
       def external_user
-        @external_user ||= Audiences::ExternalUser.unscoped.where(scim_id: scim_id).first_or_initialize
+        @external_user ||= Audiences::ExternalUser.where(scim_id: scim_id).first_or_initialize
       end
 
       def upsert_action = external_user.persisted? ? "Updating" : "Creating"
@@ -40,7 +40,7 @@ module Audiences
 
       def new_groups
         event_payload.params.fetch("groups", []).filter_map do |group|
-          Audiences::Group.unscoped.find_by(scim_id: group["value"])
+          Audiences::Group.find_by(scim_id: group["value"])
         end
       end
     end

--- a/audiences/spec/controllers/scim_proxy_controller_spec.rb
+++ b/audiences/spec/controllers/scim_proxy_controller_spec.rb
@@ -33,5 +33,25 @@ RSpec.describe Audiences::ScimProxyController do
 
       expect(response.parsed_body).to match [group3].as_json
     end
+
+    it "limits group resources by their default scope" do
+      create_group resource_type: "Groups", active: false
+      group2 = create_group resource_type: "Groups", active: true
+      group3 = create_group resource_type: "Groups", active: true
+
+      get :get, params: { scim_path: "Groups" }
+
+      expect(response.parsed_body).to match [group2, group3].as_json
+    end
+
+    it "limits user resources by their default scope" do
+      create_user active: false
+      user2 = create_user active: true
+      user3 = create_user active: true
+
+      get :get, params: { scim_path: "Users" }
+
+      expect(response.parsed_body).to match [user2, user3].as_json
+    end
   end
 end

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -13,6 +13,60 @@ RSpec.describe Audiences::Context do
       end.to yield_with_args(owner.members_context)
     end
   end
+  describe "#users" do
+    it "is all users in the database when match_all is true" do
+      users = create_users(4)
+
+      owner.save
+      owner.members_context.update!(match_all: true)
+
+      expect(owner.members_external_users).to match_array users
+    end
+
+    it "is the union of extra users and criteria matches when match_all is false" do
+      group1 = create_group
+      group2 = create_group
+      _group3 = create_group
+      group_users = create_users(2, groups: [group1, group2])
+      extra_users = create_users(2)
+
+      owner.save
+      owner.members_context.update!(extra_users: extra_users.map(&:as_json))
+
+      expect(owner.members_external_users).to match_array extra_users
+
+      owner.members_context.criteria.create!(groups: { "Groups" => [group2] }.as_json)
+
+      expect(owner.members_external_users).to match_array extra_users + group_users
+    end
+
+    it "ignores users not matching the default scope" do
+      group1 = create_group
+      group2 = create_group
+      _group3 = create_group
+      active_group_user, = create_user(groups: [group1, group2]), create_user(groups: [group1, group2], active: false)
+      active_extra_user = create_user
+      inactive_extra_user = create_user(active: false)
+
+      owner.save
+      owner.members_context.update!(extra_users: [active_extra_user, inactive_extra_user].map(&:as_json))
+
+      expect(owner.members_external_users).to match_array [active_extra_user]
+
+      owner.members_context.criteria.create!(groups: { "Groups" => [group2] }.as_json)
+
+      expect(owner.members_external_users).to match_array [active_extra_user, active_group_user]
+    end
+
+    it "is only the extra users when no criteria are set and match_all is false" do
+      extra_users = create_users(3)
+
+      owner.save
+      owner.members_context.update!(extra_users: extra_users.map(&:as_json), match_all: false)
+
+      expect(owner.members_external_users).to match_array extra_users
+    end
+  end
 
   describe "#match_all" do
     it "clears other criteria when set to match all" do

--- a/audiences/spec/models/audiences/criterion_spec.rb
+++ b/audiences/spec/models/audiences/criterion_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe Audiences::Criterion do
     it { is_expected.to belong_to(:context) }
   end
 
+  describe "validations" do
+    it "does not allow criterion groups with empty groups" do
+      criterion = Audiences::Criterion.new(groups: {})
+      expect(criterion).not_to be_valid
+      expect(criterion.errors[:groups]).to include("can't be blank")
+    end
+  end
+
   describe ".map([])" do
     it "builds contexts with the given " do
       department = create_group(resource_type: "Departments")
@@ -22,6 +30,19 @@ RSpec.describe Audiences::Criterion do
       expect(criteria.size).to eql 2
       expect(criteria.first.groups).to match({ "Departments" => [department.as_json] })
       expect(criteria.last.groups).to match({ "Territories" => [territory.as_json] })
+    end
+
+    it "allows setting creating groups not matching the default group scope" do
+      department = create_group(resource_type: "Departments", scim_id: "123", active: false)
+
+      criteria = Audiences::Criterion.map(
+        [
+          { "groups" => { "Departments" => [department.as_json] } },
+        ]
+      )
+
+      expect(criteria.size).to eql 1
+      expect(criteria.first.groups).to match({ "Departments" => [department.as_json] })
     end
   end
 

--- a/audiences/spec/observers/audiences/scim/patch_users_observer_spec.rb
+++ b/audiences/spec/observers/audiences/scim/patch_users_observer_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Audiences::Scim::PatchUsersObserver do
                                          },
                                        ],
                                      })
-    end.to_not(change { Audiences::ExternalUser.unscoped.count })
+    end.to_not(change { Audiences::ExternalUser.count })
 
     user.reload
 

--- a/audiences/spec/observers/audiences/scim/upsert_groups_observer_spec.rb
+++ b/audiences/spec/observers/audiences/scim/upsert_groups_observer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Audiences::Scim::UpsertGroupsObserver do
                "urn:ietf:params:scim:schemas:extension:authservice:2.0:Group" => { "active" => true } }
     expect do
       TwoPercent::CreateEvent.create(resource: "Groups", params: params)
-    end.to change { Audiences::Group.unscoped.count }.by(1)
+    end.to change { Audiences::Group.count }.by(1)
 
     created_group = Audiences::Group.last
 
@@ -29,7 +29,7 @@ RSpec.describe Audiences::Scim::UpsertGroupsObserver do
 
     expect do
       TwoPercent::CreateEvent.create(resource: "Groups", params: params)
-    end.to_not(change { Audiences::Group.unscoped.count })
+    end.to_not(change { Audiences::Group.count })
 
     group.reload
 
@@ -47,7 +47,7 @@ RSpec.describe Audiences::Scim::UpsertGroupsObserver do
 
     expect do
       TwoPercent::ReplaceEvent.create(resource: "Groups", params: params)
-    end.to_not(change { Audiences::Group.unscoped.count })
+    end.to_not(change { Audiences::Group.count })
 
     group.reload
 

--- a/audiences/spec/observers/audiences/scim/upsert_users_observer_spec.rb
+++ b/audiences/spec/observers/audiences/scim/upsert_users_observer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Audiences::Scim::UpsertUsersObserver do
 
     expect do
       TwoPercent::CreateEvent.create(resource: "Users", params: params)
-    end.to_not(change { Audiences::ExternalUser.unscoped.count })
+    end.to_not(change { Audiences::ExternalUser.count })
 
     user.reload
 
@@ -56,7 +56,7 @@ RSpec.describe Audiences::Scim::UpsertUsersObserver do
 
     expect do
       TwoPercent::ReplaceEvent.create(resource: "Users", params: params)
-    end.to_not(change { Audiences::ExternalUser.unscoped.count })
+    end.to_not(change { Audiences::ExternalUser.count })
 
     user.reload
 
@@ -84,9 +84,9 @@ RSpec.describe Audiences::Scim::UpsertUsersObserver do
 
     expect do
       TwoPercent::ReplaceEvent.create(resource: "Users", params: params)
-    end.to(change { Audiences::ExternalUser.unscoped.count })
+    end.to(change { Audiences::ExternalUser.count })
 
-    user = Audiences::ExternalUser.unscoped.last
+    user = Audiences::ExternalUser.last
 
     expect(user.scim_id).to eql "internal-id-123"
     expect(user.user_id).to eql "external-id-123"


### PR DESCRIPTION
This pull request refactors how default scoping is applied to the `Audiences::ExternalUser` and `Audiences::Group` models, moving from model-level default scopes to explicit, context-driven scope application.

### Impact

Default filtering for users/groups is now explicit, reducing risk of unintentional filtering.

### Changes

1. Removal of Model-Level Default Scopes
The model-level default_scope for both `Audiences::ExternalUser` and Audiences::Group is removed.

2. Explicit Application of Default Scopes
Default scopes are now applied only when needed in controllers and model methods.

3. Query and Observer Adjustments
- Eliminates unnecessary use of .unscoped in queries and observers.
- Observers and upsert logic now use unscoped access only where it’s explicitly required.

4. User and Group Matching Logic
The matching scope for users now returns none if the group list is empty, making filtering stricter and more predictable.

5. Validation Improvements
Adds validation to prevent creating criteria with empty group lists.

