### PR TITLE
[SHD-1410] Filter extra_users in context JSON

### DIFF
--- a/audiences/app/models/audiences/context.rb
+++ b/audiences/app/models/audiences/context.rb
@@ -39,7 +39,7 @@ module Audiences
       {
         match_all: match_all,
         count: count,
-        extra_users: extra_users,
+        extra_users: extra_users.instance_exec(&Audiences.default_users_scope),
         criteria: criteria,
       }.as_json(...)
     end

--- a/audiences/spec/models/audiences/context_spec.rb
+++ b/audiences/spec/models/audiences/context_spec.rb
@@ -96,4 +96,17 @@ RSpec.describe Audiences::Context do
       expect(owner.members_context.count).to eql 2
     end
   end
+
+  describe "#as_json" do
+    it "does not include users not matching the default scope" do
+      Audiences.config.default_users_scope = -> { where(active: true) }
+
+      active_user = create_user(active: true)
+      inactive_user = create_user(active: false)
+
+      context = create_context(extra_users: [active_user, inactive_user])
+
+      expect(context.as_json["extra_users"]).to eql([active_user.as_json])
+    end
+  end
 end


### PR DESCRIPTION
[SHD-1410](https://runway.powerhrg.com/backlog_items/SHD-1410)

This pull request updates the as_json method in the Audiences::Context model to ensure that the extra_users field only includes users matching the default scope defined by Audiences.default_users_scope. Previously, extra_users were included directly; now, extra_users are filtered through the default scope using instance_exec.