### PR TITLE
[GOG-1783] Add npm_token secret to audiences-react workflow

### DIFF
--- a/.github/workflows/audiences-react.yml
+++ b/.github/workflows/audiences-react.yml
@@ -10,4 +10,5 @@ jobs:
       package: ${{ github.workflow }}
       workdir: ${{ github.workflow }}
       node: '["22"]'
-    secrets: inherit
+    secrets:
+      npm_token: ${{ secrets.POWERHOME_NPM_REGISTRY_PASSWORD }}


### PR DESCRIPTION
We need to explicitly define this secret so this Action can authenticate against our internal NPM registry.

This can be seen working in action in [this run](https://github.com/powerhome/audiences/actions/runs/25753588849/job/75636066797?pr=527), which succeeded.

This should be merged after https://github.com/powerhome/github-actions-workflows/pull/40, which changes the upstream Action that this repo pulls in.