### PR TITLE
Authenticate `audiences-ruby.yml` workflow against internal registry

### DIFF
--- a/.github/workflows/audiences-ruby.yml
+++ b/.github/workflows/audiences-ruby.yml
@@ -64,6 +64,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install non-ruby dependencies
         run: sudo apt-get install libpq-dev
+      - name: Enable npm.powerapp.cloud auth
+        shell: bash
+        env:
+          NPM_REGISTRY_PASSWORD: ${{ secrets.POWERHOME_NPM_REGISTRY_PASSWORD }}
+        run: |
+          auth="$(printf 'gh-actions:%s' "$NPM_REGISTRY_PASSWORD" | base64 | tr -d '\n')"
+          echo "::add-mask::$auth"
+          {
+            echo "registry=https://npm.powerapp.cloud"
+            echo "//npm.powerapp.cloud/:_auth=${auth}"
+            echo "//npm.powerapp.cloud/:always-auth=true"
+          } >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
       - name: 'mysql2 adapter'
         uses: powerhome/github-actions-workflows/build-ruby-gem@main
         env:


### PR DESCRIPTION
Similar to the change in https://github.com/powerhome/github-actions-workflows/pull/40, this PR adds a step to authenticate against our internal NPM registry so it can pull the NPM packages that Renovate rewrites.

This can be seen completing successfully when [this same change](https://github.com/powerhome/audiences/commit/d02dbb4caca17e3a6c2bbe74fa8db939163d64ee) is applied to a branch [in this workflow](https://github.com/powerhome/audiences/actions/runs/26103629586?pr=545).