### PR TITLE
[JEDI-962] Fix RLD territory name

### DIFF
--- a/audiences/Gemfile.lock
+++ b/audiences/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    audiences (2.0.1)
+    audiences (2.0.2)
       aether_observatory (~> 1.0)
       rails (>= 6.0)
 

--- a/audiences/docs/CHANGELOG.md
+++ b/audiences/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 2.0.2 (2026-06-11)
+
+- Update territory name from "Raleigh" to "Raleigh-Durham"
+
 # Version 2.0.1 (2026-05-08)
 
 - Fixes a performance issue where we load all users when updating memberships [#557](https://github.com/powerhome/audiences/pull/557)

--- a/audiences/gemfiles/rails_6_1.gemfile.lock
+++ b/audiences/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (2.0.1)
+    audiences (2.0.2)
       aether_observatory (~> 1.0)
       rails (>= 6.0)
 

--- a/audiences/gemfiles/rails_7_0.gemfile.lock
+++ b/audiences/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (2.0.1)
+    audiences (2.0.2)
       aether_observatory (~> 1.0)
       rails (>= 6.0)
 

--- a/audiences/gemfiles/rails_7_1.gemfile.lock
+++ b/audiences/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    audiences (2.0.1)
+    audiences (2.0.2)
       aether_observatory (~> 1.0)
       rails (>= 6.0)
 

--- a/audiences/lib/audiences/configuration.rb
+++ b/audiences/lib/audiences/configuration.rb
@@ -28,7 +28,7 @@ module Audiences
     "Austin" => "AUS", "Charlotte" => "CLT", "Nashville" => "NSH", "Phoenix" => "PHX",
     "Pittsburgh" => "PIT", "San Antonio" => "SAO", "Fort Lauderdale" => "FLL", "Las Vegas" => "LVS",
     "Orlando" => "ORL", "Cincinnati" => "CIN", "Columbus" => "CLB", "Jacksonville" => "JAX",
-    "Oklahoma City" => "OKC", "Raleigh" => "RLD", "Cleveland" => "CLE"
+    "Oklahoma City" => "OKC", "Raleigh-Durham" => "RLD", "Cleveland" => "CLE"
   }.freeze
 
   config_accessor(:territory_abbreviations) { DEFAULT_TERRITORY_ABBREVIATIONS }

--- a/audiences/lib/audiences/version.rb
+++ b/audiences/lib/audiences/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Audiences
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
This PR updates the RLD territory to match to the correct Territory name. It was incorrect and not setting Users' territory abbreviation correctly.